### PR TITLE
fix typescript errors by installing @types/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@types/chai": "^4.2.10",
         "@types/mocha": "^7.0.2",
+        "@types/node": "^14.0.20",
         "chai": "^4.2.0",
         "coveralls": "^3.0.9",
         "husky": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -166,6 +166,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.5.tgz#c1920150f7b90708a7d0f3add12a06bc9123c055"
   integrity sha512-RElZIr/7JreF1eY6oD5RF3kpmdcreuQPjg5ri4oQ5g9sq7YWU8HkfB3eH8GwAwxf5OaCh0VPi7r4N/yoTGelrA==
 
+"@types/node@^14.0.20":
+  version "14.0.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.20.tgz#0da05cddbc761e1fa98af88a17244c8c1ff37231"
+  integrity sha512-MRn/NP3dee8yL5QhbSA6riuwkS+UOcsPUMOIOG3KMUQpuor/2TopdRBu8QaaB4fGU+gz/bzyDWt0FtUbeJ8H1A==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
I was experiencing errors from typescript about it not knowing about `require` and `console` requiring the install of this package to fix them.