### PR TITLE
build: make typescript a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
         "nyc": "^15.0.0",
         "prettier": "^1.19.1",
         "pretty-quick": "^2.0.1",
-        "ts-node": "^8.6.2"
+        "ts-node": "^8.6.2",
+        "typescript": "^3.8.3"
     },
     "dependencies": {
         "bignumber.js": "^9.0.0",
         "ethers": "^4.0.39",
-        "isomorphic-fetch": "^2.2.1",
-        "typescript": "^3.8.3"
+        "isomorphic-fetch": "^2.2.1"
     }
 }


### PR DESCRIPTION
Typescript isn't necessary for users of this library so it should be a dev dependency