### PR TITLE
fix: floor swapAmountForSwaps to remove decimal places

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -291,7 +291,7 @@ export class SOR {
                 (isStethIn && swapType === SwapTypes.SwapExactIn) ||
                 (isStethOut && swapType === SwapTypes.SwapExactOut)
             ) {
-                swapAmountForSwaps = swapAmt.times(rate);
+                swapAmountForSwaps = swapAmt.times(rate).dp(0);
                 // console.log(`!!!!!!! rating SwapAmt ${swapAmountForSwaps.toString()}`);
             }
 


### PR DESCRIPTION
I'm getting failing transactions due to decimal places in the swap amounts, I think this is where it's creeping in.