### PR TITLE
refactor: add static functions to create pool classes from subgraph response

### DIFF
--- a/src/pools.ts
+++ b/src/pools.ts
@@ -121,62 +121,19 @@ export function parseNewPool(
 ): WeightedPool | StablePool | ElementPool | undefined {
     let newPool: WeightedPool | StablePool | ElementPool;
     if (pool.poolType === 'Weighted')
-        newPool = new WeightedPool(
-            pool.id,
-            pool.address,
-            pool.swapFee,
-            pool.totalWeight,
-            pool.totalShares,
-            pool.tokens,
-            pool.tokensList
-        );
+        newPool = WeightedPool.fromPool(pool);
     else if (pool.poolType === 'Stable')
-        newPool = new StablePool(
-            pool.id,
-            pool.address,
-            pool.amp,
-            pool.swapFee,
-            pool.totalShares,
-            pool.tokens,
-            pool.tokensList
-        );
+        newPool = StablePool.fromPool(pool);
     else if (pool.poolType === 'Element') {
-        newPool = new ElementPool(
-            pool.id,
-            pool.address,
-            pool.swapFee,
-            pool.totalShares,
-            pool.tokens,
-            pool.tokensList,
-            pool.expiryTime,
-            pool.unitSeconds,
-            pool.principalToken,
-            pool.baseToken
-        );
+        newPool = ElementPool.fromPool(pool);
         newPool.setCurrentBlockTimestamp(currentBlockTimestamp);
     } else if (pool.poolType === 'MetaStable') {
-        newPool = new MetaStablePool(
-            pool.id,
-            pool.address,
-            pool.amp,
-            pool.swapFee,
-            pool.totalShares,
-            pool.tokens,
-            pool.tokensList
-        );
+        newPool = MetaStablePool.fromPool(pool);
     } else if (pool.poolType === 'LiquidityBootstrapping') {
         // If an LBP doesn't have its swaps paused we treat it like a regular Weighted pool.
         // If it does we just ignore it.
         if (pool.swapEnabled === true)
-            newPool = new WeightedPool(
-                pool.id,
-                pool.address,
-                pool.swapFee,
-                pool.totalWeight,
-                pool.totalShares,
-                pool.tokens,
-                pool.tokensList
-            );
+            newPool = WeightedPool.fromPool(pool);
         else return undefined;
     } else {
         console.error(

--- a/src/pools/elementPool/elementPool.ts
+++ b/src/pools/elementPool/elementPool.ts
@@ -6,6 +6,7 @@ import {
     PairTypes,
     PoolPairBase,
     SwapTypes,
+    SubgraphPoolBase,
 } from '../../types';
 import { getAddress } from '@ethersproject/address';
 import { bnum } from '../../bmath';
@@ -62,6 +63,23 @@ export class ElementPool implements PoolBase {
     baseToken: string;
     currentBlockTimestamp: number;
 
+    static fromPool(
+        pool: SubgraphPoolBase
+    ): ElementPool {
+        return new ElementPool(
+            pool.id,
+            pool.address,
+            pool.swapFee,
+            pool.totalShares,
+            pool.tokens,
+            pool.tokensList,
+            pool.expiryTime,
+            pool.unitSeconds,
+            pool.principalToken,
+            pool.baseToken
+        );
+    }
+    
     constructor(
         id: string,
         address: string,

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -6,6 +6,7 @@ import {
     PairTypes,
     PoolPairBase,
     SwapTypes,
+    SubgraphPoolBase,
 } from '../../types';
 import { getAddress } from '@ethersproject/address';
 import { bnum, scale, ZERO } from '../../bmath';
@@ -77,6 +78,20 @@ export class MetaStablePool implements PoolBase {
     MAX_IN_RATIO = bnum(0.3);
     MAX_OUT_RATIO = bnum(0.3);
     ampAdjusted: BigNumber;
+
+    static fromPool(
+        pool: SubgraphPoolBase
+    ): MetaStablePool {
+        return new MetaStablePool(
+            pool.id,
+            pool.address,
+            pool.amp,
+            pool.swapFee,
+            pool.totalShares,
+            pool.tokens,
+            pool.tokensList
+        )
+    }
 
     constructor(
         id: string,

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -6,6 +6,7 @@ import {
     PairTypes,
     PoolPairBase,
     SwapTypes,
+    SubgraphPoolBase,
 } from '../../types';
 import { getAddress } from '@ethersproject/address';
 import { bnum, scale, ZERO } from '../../bmath';
@@ -75,6 +76,20 @@ export class StablePool implements PoolBase {
     MAX_OUT_RATIO = bnum(0.3);
     ampAdjusted: BigNumber;
 
+    static fromPool(
+        pool: SubgraphPoolBase
+    ): StablePool {
+        return new StablePool(
+            pool.id,
+            pool.address,
+            pool.amp,
+            pool.swapFee,
+            pool.totalShares,
+            pool.tokens,
+            pool.tokensList
+        );
+    }
+    
     constructor(
         id: string,
         address: string,

--- a/src/pools/weightedPool/weightedPool.ts
+++ b/src/pools/weightedPool/weightedPool.ts
@@ -9,6 +9,7 @@ import {
     PairTypes,
     PoolPairBase,
     SwapTypes,
+    SubgraphPoolBase,
 } from '../../types';
 import {
     _exactTokenInForTokenOut,
@@ -67,6 +68,20 @@ export class WeightedPool implements PoolBase {
     MAX_IN_RATIO = bnum(0.3);
     MAX_OUT_RATIO = bnum(0.3);
 
+    static fromPool(
+        pool: SubgraphPoolBase
+    ): WeightedPool {
+        return new WeightedPool(
+            pool.id,
+            pool.address,
+            pool.swapFee,
+            pool.totalWeight,
+            pool.totalShares,
+            pool.tokens,
+            pool.tokensList
+        );
+    }
+    
     constructor(
         id: string,
         address: string,


### PR DESCRIPTION
I've moved the breaking out of constructor params for the pool helper classes into a static method which cleans up the `parseNewPool` function a bit.