### PR TITLE
Remove subgraph env var

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-require('dotenv').config();
 export * from './constants';
 export { fetchSubgraphPools } from './subgraph';
 export { getOnChainBalances } from './multicall';

--- a/src/subgraph.ts
+++ b/src/subgraph.ts
@@ -1,11 +1,10 @@
 import fetch from 'isomorphic-fetch';
-
-const SUBGRAPH_URL =
-    process.env.SUBGRAPH_URL ||
-    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2';
+import { SubGraphPoolsBase } from 'types';
 
 // Returns all public pools
-export async function fetchSubgraphPools(SubgraphUrl: string = '') {
+export async function fetchSubgraphPools(
+    subgraphUrl: string
+): Promise<SubGraphPoolsBase> {
     // can filter for publicSwap too??
     const query = `
       {
@@ -34,22 +33,17 @@ export async function fetchSubgraphPools(SubgraphUrl: string = '') {
       }
     `;
 
-    console.log(
-        `fetchSubgraphPools: ${SubgraphUrl === '' ? SUBGRAPH_URL : SubgraphUrl}`
-    );
-    const response = await fetch(
-        SubgraphUrl === '' ? SUBGRAPH_URL : SubgraphUrl,
-        {
-            method: 'POST',
-            headers: {
-                Accept: 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                query,
-            }),
-        }
-    );
+    console.log(`fetchSubgraphPools: ${subgraphUrl}`);
+    const response = await fetch(subgraphUrl, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            query,
+        }),
+    });
 
     const { data } = await response.json();
 


### PR DESCRIPTION
I'm not seeing a ton of value from this environment variable and I remember it causing some issues for use around the time of the V2 launch. Thoughts on just removing it and ensuring that user passes a subgraph url? (We seem to be doing this already anyway so only change is if someone it querying this function directly)