### PR TITLE
Refactor SOR.getSwaps and SOR.processSwaps

### DIFF
--- a/src/pools.ts
+++ b/src/pools.ts
@@ -7,6 +7,7 @@ import {
     NewPath,
     Swap,
     PoolBase,
+    PoolFilter,
 } from './types';
 import { WeightedPool } from './pools/weightedPool/weightedPool';
 import { StablePool } from './pools/stablePool/stablePool';
@@ -15,6 +16,14 @@ import { MetaStablePool } from './pools/metaStablePool/metaStablePool';
 import { ZERO } from './utils/bignumber';
 
 import disabledTokensDefault from './disabled-tokens.json';
+
+export const filterPoolsByType = (
+    pools: SubgraphPoolBase[],
+    poolTypeFilter: PoolFilter
+): SubgraphPoolBase[] => {
+    if (poolTypeFilter === PoolFilter.All) return pools;
+    return pools.filter(p => p.poolType === poolTypeFilter);
+};
 
 /*
 The main purpose of this function is to:

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -40,7 +40,7 @@ export class SOR {
     isUsingPoolsUrl: boolean;
     poolsUrl: string;
     subgraphPools: SubGraphPoolsBase;
-    tokenCost = {};
+    private tokenCost: Record<string, BigNumber> = {};
     onChainBalanceCache: SubGraphPoolsBase = { pools: [] };
     processedDataCache: Record<
         string,
@@ -75,6 +75,11 @@ export class SOR {
             this.subgraphPools = poolsSource;
         }
         this.disabledOptions = disabledOptions;
+    }
+
+    getCostOutputToken(outputToken: string): BigNumber {
+        // Use previously stored value if exists else default to 0
+        return this.tokenCost[outputToken.toLowerCase()] ?? ZERO;
     }
 
     /*
@@ -295,6 +300,7 @@ export class SOR {
         currentBlockTimestamp = 0
     ): Promise<SwapInfo> {
         if (onChainPools.pools.length === 0) {
+            // null SwapInfo
             return {
                 tokenAddresses: [],
                 swaps: [],
@@ -318,15 +324,9 @@ export class SOR {
             currentBlockTimestamp
         );
 
-        let costOutputToken = this.tokenCost[tokenOut];
-
-        if (swapType === SwapTypes.SwapExactOut)
-            costOutputToken = this.tokenCost[tokenIn];
-
-        // Use previously stored value if exists else default to 0
-        if (costOutputToken === undefined) {
-            costOutputToken = new BigNumber(0);
-        }
+        const costOutputToken = this.getCostOutputToken(
+            swapType === SwapTypes.SwapExactIn ? tokenOut : tokenIn
+        );
 
         // Returns list of swaps
         const [

--- a/test/wrapper.spec.ts
+++ b/test/wrapper.spec.ts
@@ -56,7 +56,7 @@ describe(`Tests for wrapper class.`, () => {
         const manualCost = new BigNumber('700000000000');
         const sor = new SOR(provider, gasPrice, maxPools, chainId, poolsUrl);
         sor.setCostOutputToken(tokenOut, 18, manualCost);
-        assert.equal(manualCost, sor.tokenCost[tokenOut]);
+        assert.equal(manualCost, sor.getCostOutputToken(tokenOut));
     });
 
     it(`Should return correct costOutputToken for ZERO & WETH addresses`, async () => {
@@ -70,7 +70,10 @@ describe(`Tests for wrapper class.`, () => {
                 .div(bnum(10 ** 18))
                 .toString()
         );
-        assert.equal(cost.toString(), sor.tokenCost[tokenOut]);
+        assert.equal(
+            cost.toString(),
+            sor.getCostOutputToken(tokenOut).toString()
+        );
         cost = await sor.setCostOutputToken(WETHADDR, 18);
         assert.equal(
             cost.toString(),
@@ -79,7 +82,10 @@ describe(`Tests for wrapper class.`, () => {
                 .div(bnum(10 ** 18))
                 .toString()
         );
-        assert.equal(cost.toString(), sor.tokenCost[WETHADDR]);
+        assert.equal(
+            cost.toString(),
+            sor.getCostOutputToken(WETHADDR).toString()
+        );
     });
 
     // Valid test but outputs large error


### PR DESCRIPTION
I've split `SOR.getSwaps` and `SOR.processSwaps` into helper functions to remove some of the branches in the main function. This should make it easier for us to reorganise this functionality in future if we decide we want to move it elsewhere.