### PR TITLE
feat: only use evm maths for stable/metastable pools

### DIFF
--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -13,12 +13,6 @@ import { bnum, scale, ZERO } from '../../utils/bignumber';
 import * as SDK from '@georgeroman/balancer-v2-pools';
 import {
     _invariant,
-    _exactTokenInForTokenOut,
-    _exactTokenInForBPTOut,
-    _exactBPTInForTokenOut,
-    _tokenInForExactTokenOut,
-    _tokenInForExactBPTOut,
-    _BPTInForExactTokenOut,
     _spotPriceAfterSwapExactTokenInForTokenOut,
     _spotPriceAfterSwapExactTokenInForBPTOut,
     _spotPriceAfterSwapExactBPTInForTokenOut,
@@ -249,38 +243,28 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const amtScaled = scale(amount, 18);
-                const amountConverted = amtScaled.times(
-                    poolPairData.tokenInPriceRate
-                );
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const amtScaled = scale(amount, 18);
+            const amountConverted = amtScaled.times(
+                poolPairData.tokenInPriceRate
+            );
 
-                const amt = SDK.StableMath._calcOutGivenIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    poolPairData.tokenIndexOut,
-                    amountConverted,
-                    poolPairData.swapFeeScaled
-                );
-                // return normalised amount
-                return scale(amt.div(poolPairData.tokenOutPriceRate), -18);
-            } catch (err) {
-                console.error(`_evmoutGivenIn: ${err.message}`);
-                return ZERO;
-            }
+            const amt = SDK.StableMath._calcOutGivenIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                poolPairData.tokenIndexOut,
+                amountConverted,
+                poolPairData.swapFeeScaled
+            );
+            // return normalised amount
+            return scale(amt.div(poolPairData.tokenOutPriceRate), -18);
+        } catch (err) {
+            console.error(`_evmoutGivenIn: ${err.message}`);
+            return ZERO;
         }
-        // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
-        // i.e. when using token with 2decimals 0.002 should be returned as 0
-        // Uses ROUND_DOWN mode (1)
-        const amt = _exactTokenInForTokenOut(
-            amount.times(poolPairData.tokenInPriceRate),
-            poolPairData
-        ).dp(poolPairData.decimalsOut, 1);
-        return amt.div(poolPairData.tokenOutPriceRate);
     }
 
     _exactTokenInForBPTOut(
@@ -288,34 +272,30 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
-                // amountsIn must have same length as balances. Only need value for token in.
-                const amountsIn = poolPairData.allBalances.map((bal, i) => {
-                    if (i === poolPairData.tokenIndexIn)
-                        return scale(amount, 18);
-                    else return ZERO;
-                });
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
+            // amountsIn must have same length as balances. Only need value for token in.
+            const amountsIn = poolPairData.allBalances.map((bal, i) => {
+                if (i === poolPairData.tokenIndexIn) return scale(amount, 18);
+                else return ZERO;
+            });
 
-                const amt = SDK.StableMath._calcBptOutGivenExactTokensIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    amountsIn,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcBptOutGivenExactTokensIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                amountsIn,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmexactTokenInForBPTOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmexactTokenInForBPTOut: ${err.message}`);
+            return ZERO;
         }
-        return _exactTokenInForBPTOut(amount, poolPairData);
     }
 
     _exactBPTInForTokenOut(
@@ -323,30 +303,27 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptAmountInScaled = scale(amount, 18);
-                const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptAmountInScaled = scale(amount, 18);
+            const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
 
-                const amt = SDK.StableMath._calcTokenOutGivenExactBptIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexOut,
-                    bptAmountInScaled,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcTokenOutGivenExactBptIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexOut,
+                bptAmountInScaled,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmexactBPTInForTokenOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmexactBPTInForTokenOut: ${err.message}`);
+            return ZERO;
         }
-        return _exactBPTInForTokenOut(amount, poolPairData);
     }
 
     _tokenInForExactTokenOut(
@@ -354,40 +331,29 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const amtScaled = scale(amount, 18);
-                const amountConverted = amtScaled.times(
-                    poolPairData.tokenOutPriceRate
-                );
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const amtScaled = scale(amount, 18);
+            const amountConverted = amtScaled.times(
+                poolPairData.tokenOutPriceRate
+            );
 
-                const amt = SDK.StableMath._calcInGivenOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    poolPairData.tokenIndexOut,
-                    amountConverted,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcInGivenOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                poolPairData.tokenIndexOut,
+                amountConverted,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt.div(poolPairData.tokenInPriceRate), -18);
-            } catch (err) {
-                console.error(`_evminGivenOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt.div(poolPairData.tokenInPriceRate), -18);
+        } catch (err) {
+            console.error(`_evminGivenOut: ${err.message}`);
+            return ZERO;
         }
-        // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
-        // i.e. when using token with 2decimals 0.002 should be returned as 0
-        // Uses ROUND_UP mode (0)
-        const amt = _tokenInForExactTokenOut(
-            amount.times(poolPairData.tokenOutPriceRate),
-            poolPairData
-        ).dp(poolPairData.decimalsIn, 0);
-
-        return amt.div(poolPairData.tokenInPriceRate);
     }
 
     _tokenInForExactBPTOut(
@@ -395,30 +361,27 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptAmountOutScaled = scale(amount, 18);
-                const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptAmountOutScaled = scale(amount, 18);
+            const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
 
-                const amt = SDK.StableMath._calcTokenInGivenExactBptOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    bptAmountOutScaled,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcTokenInGivenExactBptOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                bptAmountOutScaled,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmtokenInForExactBPTOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmtokenInForExactBPTOut: ${err.message}`);
+            return ZERO;
         }
-        return _tokenInForExactBPTOut(amount, poolPairData);
     }
 
     _BPTInForExactTokenOut(
@@ -426,33 +389,29 @@ export class MetaStablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                // amountsOut must have same length as balances. Only need value for token out.
-                const amountsOut = poolPairData.allBalances.map((bal, i) => {
-                    if (i === poolPairData.tokenIndexOut)
-                        return scale(amount, 18);
-                    else return ZERO;
-                });
-                const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            // amountsOut must have same length as balances. Only need value for token out.
+            const amountsOut = poolPairData.allBalances.map((bal, i) => {
+                if (i === poolPairData.tokenIndexOut) return scale(amount, 18);
+                else return ZERO;
+            });
+            const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
 
-                const amt = SDK.StableMath._calcBptInGivenExactTokensOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    amountsOut,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmbptInForExactTokenOut: ${err.message}`);
-                return ZERO;
-            }
+            const amt = SDK.StableMath._calcBptInGivenExactTokensOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                amountsOut,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmbptInForExactTokenOut: ${err.message}`);
+            return ZERO;
         }
-        return _BPTInForExactTokenOut(amount, poolPairData);
     }
 
     _spotPriceAfterSwapExactTokenInForTokenOut(

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -260,7 +260,13 @@ export class MetaStablePool implements PoolBase {
                 poolPairData.swapFeeScaled
             );
             // return normalised amount
-            return scale(amt.div(poolPairData.tokenOutPriceRate), -18);
+            // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
+            // i.e. when using token with 2decimals 0.002 should be returned as 0
+            // Uses ROUND_DOWN mode (1)
+            return scale(amt.div(poolPairData.tokenOutPriceRate), -18).dp(
+                poolPairData.decimalsOut,
+                1
+            );
         } catch (err) {
             console.error(`_evmoutGivenIn: ${err.message}`);
             return ZERO;
@@ -349,7 +355,13 @@ export class MetaStablePool implements PoolBase {
             );
 
             // return normalised amount
-            return scale(amt.div(poolPairData.tokenInPriceRate), -18);
+            // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
+            // i.e. when using token with 2decimals 0.002 should be returned as 0
+            // Uses ROUND_UP mode (0)
+            return scale(amt.div(poolPairData.tokenInPriceRate), -18).dp(
+                poolPairData.decimalsIn,
+                0
+            );
         } catch (err) {
             console.error(`_evminGivenOut: ${err.message}`);
             return ZERO;

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -13,12 +13,6 @@ import { bnum, scale, ZERO } from '../../utils/bignumber';
 import * as SDK from '@georgeroman/balancer-v2-pools';
 import {
     _invariant,
-    _exactTokenInForTokenOut,
-    _exactTokenInForBPTOut,
-    _exactBPTInForTokenOut,
-    _tokenInForExactTokenOut,
-    _tokenInForExactBPTOut,
-    _BPTInForExactTokenOut,
     _spotPriceAfterSwapExactTokenInForTokenOut,
     _spotPriceAfterSwapExactTokenInForBPTOut,
     _spotPriceAfterSwapExactBPTInForTokenOut,
@@ -227,35 +221,26 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const amtScaled = scale(amount, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const amtScaled = scale(amount, 18);
 
-                const amt = SDK.StableMath._calcOutGivenIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    poolPairData.tokenIndexOut,
-                    amtScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcOutGivenIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                poolPairData.tokenIndexOut,
+                amtScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmoutGivenIn: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmoutGivenIn: ${err.message}`);
+            return ZERO;
         }
-        // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
-        // i.e. when using token with 2decimals 0.002 should be returned as 0
-        // Uses ROUND_DOWN mode (1)
-        return _exactTokenInForTokenOut(amount, poolPairData).dp(
-            poolPairData.decimalsOut,
-            1
-        );
     }
 
     _exactTokenInForBPTOut(
@@ -263,34 +248,30 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
-                // amountsIn must have same length as balances. Only need value for token in.
-                const amountsIn = poolPairData.allBalances.map((bal, i) => {
-                    if (i === poolPairData.tokenIndexIn)
-                        return scale(amount, 18);
-                    else return ZERO;
-                });
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
+            // amountsIn must have same length as balances. Only need value for token in.
+            const amountsIn = poolPairData.allBalances.map((bal, i) => {
+                if (i === poolPairData.tokenIndexIn) return scale(amount, 18);
+                else return ZERO;
+            });
 
-                const amt = SDK.StableMath._calcBptOutGivenExactTokensIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    amountsIn,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcBptOutGivenExactTokensIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                amountsIn,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmexactTokenInForBPTOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmexactTokenInForBPTOut: ${err.message}`);
+            return ZERO;
         }
-        return _exactTokenInForBPTOut(amount, poolPairData);
     }
 
     _exactBPTInForTokenOut(
@@ -298,30 +279,27 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptAmountInScaled = scale(amount, 18);
-                const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptAmountInScaled = scale(amount, 18);
+            const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
 
-                const amt = SDK.StableMath._calcTokenOutGivenExactBptIn(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexOut,
-                    bptAmountInScaled,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcTokenOutGivenExactBptIn(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexOut,
+                bptAmountInScaled,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmexactBPTInForTokenOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmexactBPTInForTokenOut: ${err.message}`);
+            return ZERO;
         }
-        return _exactBPTInForTokenOut(amount, poolPairData);
     }
 
     _tokenInForExactTokenOut(
@@ -329,35 +307,26 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const amtScaled = scale(amount, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const amtScaled = scale(amount, 18);
 
-                const amt = SDK.StableMath._calcInGivenOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    poolPairData.tokenIndexOut,
-                    amtScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcInGivenOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                poolPairData.tokenIndexOut,
+                amtScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evminGivenOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evminGivenOut: ${err.message}`);
+            return ZERO;
         }
-        // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
-        // i.e. when using token with 2decimals 0.002 should be returned as 0
-        // Uses ROUND_UP mode (0)
-        return _tokenInForExactTokenOut(amount, poolPairData).dp(
-            poolPairData.decimalsIn,
-            0
-        );
     }
 
     _tokenInForExactBPTOut(
@@ -365,30 +334,27 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                const bptAmountOutScaled = scale(amount, 18);
-                const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            const bptAmountOutScaled = scale(amount, 18);
+            const bptTotalSupplyScaled = scale(poolPairData.balanceOut, 18);
 
-                const amt = SDK.StableMath._calcTokenInGivenExactBptOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    poolPairData.tokenIndexIn,
-                    bptAmountOutScaled,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
+            const amt = SDK.StableMath._calcTokenInGivenExactBptOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                poolPairData.tokenIndexIn,
+                bptAmountOutScaled,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
 
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmtokenInForExactBPTOut: ${err.message}`);
-                return ZERO;
-            }
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmtokenInForExactBPTOut: ${err.message}`);
+            return ZERO;
         }
-        return _tokenInForExactBPTOut(amount, poolPairData);
     }
 
     _BPTInForExactTokenOut(
@@ -396,33 +362,29 @@ export class StablePool implements PoolBase {
         amount: BigNumber,
         exact: boolean
     ): BigNumber {
-        if (exact) {
-            try {
-                // All values should use 1e18 fixed point
-                // i.e. 1USDC => 1e18 not 1e6
-                // amountsOut must have same length as balances. Only need value for token out.
-                const amountsOut = poolPairData.allBalances.map((bal, i) => {
-                    if (i === poolPairData.tokenIndexOut)
-                        return scale(amount, 18);
-                    else return ZERO;
-                });
-                const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
+        try {
+            // All values should use 1e18 fixed point
+            // i.e. 1USDC => 1e18 not 1e6
+            // amountsOut must have same length as balances. Only need value for token out.
+            const amountsOut = poolPairData.allBalances.map((bal, i) => {
+                if (i === poolPairData.tokenIndexOut) return scale(amount, 18);
+                else return ZERO;
+            });
+            const bptTotalSupplyScaled = scale(poolPairData.balanceIn, 18);
 
-                const amt = SDK.StableMath._calcBptInGivenExactTokensOut(
-                    this.ampAdjusted,
-                    poolPairData.allBalancesScaled,
-                    amountsOut,
-                    bptTotalSupplyScaled,
-                    poolPairData.swapFeeScaled
-                );
-                // return normalised amount
-                return scale(amt, -18);
-            } catch (err) {
-                console.error(`_evmbptInForExactTokenOut: ${err.message}`);
-                return ZERO;
-            }
+            const amt = SDK.StableMath._calcBptInGivenExactTokensOut(
+                this.ampAdjusted,
+                poolPairData.allBalancesScaled,
+                amountsOut,
+                bptTotalSupplyScaled,
+                poolPairData.swapFeeScaled
+            );
+            // return normalised amount
+            return scale(amt, -18);
+        } catch (err) {
+            console.error(`_evmbptInForExactTokenOut: ${err.message}`);
+            return ZERO;
         }
-        return _BPTInForExactTokenOut(amount, poolPairData);
     }
 
     _spotPriceAfterSwapExactTokenInForTokenOut(

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -236,7 +236,10 @@ export class StablePool implements PoolBase {
             );
 
             // return normalised amount
-            return scale(amt, -18);
+            // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
+            // i.e. when using token with 2decimals 0.002 should be returned as 0
+            // Uses ROUND_DOWN mode (1)
+            return scale(amt, -18).dp(poolPairData.decimalsOut, 1);
         } catch (err) {
             console.error(`_evmoutGivenIn: ${err.message}`);
             return ZERO;
@@ -322,7 +325,10 @@ export class StablePool implements PoolBase {
             );
 
             // return normalised amount
-            return scale(amt, -18);
+            // Using BigNumber.js decimalPlaces (dp), allows us to consider token decimal accuracy correctly,
+            // i.e. when using token with 2decimals 0.002 should be returned as 0
+            // Uses ROUND_UP mode (0)
+            return scale(amt, -18).dp(poolPairData.decimalsIn, 0);
         } catch (err) {
             console.error(`_evminGivenOut: ${err.message}`);
             return ZERO;

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -252,7 +252,7 @@ describe(`Tests for Stable Pools.`, () => {
             console.log(`Return amt:`);
             console.log(swapInfo.returnAmount.toString());
             // This value is hard coded as sanity check if things unexpectedly change. Taken from V2 test run (with extra fee logic added).
-            expect(swapInfo.returnAmount.toString()).eq('1000400');
+            expect(swapInfo.returnAmount.toString()).eq('1000401');
             expect(swapInfo.swaps.length).eq(1);
             expect(swapInfo.swaps[0].amount.toString()).eq(
                 swapAmt.times(1e6).toString()
@@ -477,7 +477,7 @@ describe(`Tests for Stable Pools.`, () => {
             );
 
             // This value is hard coded as sanity check if things unexpectedly change. Taken from V2 test run (with extra fee logic added).
-            expect(swapInfo.returnAmount.toString()).eq('18089531');
+            expect(swapInfo.returnAmount.toString()).eq('18089532');
             expect(swapInfo.swaps.length).eq(2);
             expect(swapInfo.swaps[0].amount.toString()).eq(
                 swapAmt.times(1e18).toString()


### PR DESCRIPTION
I've deleted the behaviour to use the less accurate but faster trade functions on stable/metastable pools.

@johngrantuk This is causing a couple of the tests to fail. The tests are for checking that results match with V1 but I'm not sure how changes to the stable pool logic would cause this to fail (as no stablepools on V1). Do you have any ideas?