### PR TITLE
Scales costOutputToken to human numbers for use in optimizeSwapAmounts.

### DIFF
--- a/src/routeProposal/filtering.ts
+++ b/src/routeProposal/filtering.ts
@@ -237,15 +237,15 @@ function createDirectPath(
     tokenIn: string,
     tokenOut: string
 ): NewPath {
+    const poolPairData = pool.parsePoolPairData(tokenIn, tokenOut);
+
     const swap: Swap = {
         pool: pool.id,
         tokenIn: tokenIn,
         tokenOut: tokenOut,
-        tokenInDecimals: 18, // TO DO - Add decimals here
-        tokenOutDecimals: 18,
+        tokenInDecimals: poolPairData.decimalsIn,
+        tokenOutDecimals: poolPairData.decimalsOut,
     };
-
-    const poolPairData = pool.parsePoolPairData(tokenIn, tokenOut);
 
     const path: NewPath = {
         id: pool.id,
@@ -265,24 +265,24 @@ function createMultihopPath(
     hopToken: string,
     tokenOut: string
 ): NewPath {
+    const poolPairDataFirst = firstPool.parsePoolPairData(tokenIn, hopToken);
+    const poolPairDataSecond = secondPool.parsePoolPairData(hopToken, tokenOut);
+
     const swap1: Swap = {
         pool: firstPool.id,
         tokenIn: tokenIn,
         tokenOut: hopToken,
-        tokenInDecimals: 18, // Placeholder for actual decimals TO DO
-        tokenOutDecimals: 18,
+        tokenInDecimals: poolPairDataFirst.decimalsIn,
+        tokenOutDecimals: poolPairDataSecond.decimalsOut,
     };
 
     const swap2: Swap = {
         pool: secondPool.id,
         tokenIn: hopToken,
         tokenOut: tokenOut,
-        tokenInDecimals: 18, // Placeholder for actual decimals TO DO
-        tokenOutDecimals: 18,
+        tokenInDecimals: poolPairDataSecond.decimalsIn,
+        tokenOutDecimals: poolPairDataSecond.decimalsOut,
     };
-
-    const poolPairDataFirst = firstPool.parsePoolPairData(tokenIn, hopToken);
-    const poolPairDataSecond = secondPool.parsePoolPairData(hopToken, tokenOut);
 
     // Path id is the concatenation of the ids of poolFirstHop and poolSecondHop
     const path: NewPath = {

--- a/src/swapCost/index.ts
+++ b/src/swapCost/index.ts
@@ -108,7 +108,7 @@ export class SwapCostCalculator {
         );
     }
 
-    private async getTokenDecimals(tokenAddress: string): Promise<number> {
+    async getTokenDecimals(tokenAddress: string): Promise<number> {
         const cache = this.tokenDecimalsCache[tokenAddress.toLowerCase()];
         if (cache !== undefined) {
             return cache;


### PR DESCRIPTION
getCostOfSwapInToken returns EVM scaled numbers but optimizeSwapAmounts needs human-scaled. 
I ended up scaling in the wrapper to make use of the token address and decimal information. This isn’t readily available near the call for optimizeSwapAmounts. It could be pulled out of the Path information but seems like it’s a bit unnecessary although let me know if you feel differently.
Also fixed filtering to use correct decimals.