### PR TITLE
Optimise subgraph query

### DIFF
--- a/src/poolCaching/subgraph.ts
+++ b/src/poolCaching/subgraph.ts
@@ -8,7 +8,12 @@ export async function fetchSubgraphPools(
     // can filter for publicSwap too??
     const query = `
       {
-        pools: pools(first: 1000, where: { swapEnabled: true }) {
+        pools: pools(
+          first: 1000,
+          where: { swapEnabled: true },
+          orderBy: totalLiquidity,
+          orderDirection: desc
+        ) {
           id
           address
           poolType

--- a/src/poolCaching/subgraph.ts
+++ b/src/poolCaching/subgraph.ts
@@ -8,7 +8,7 @@ export async function fetchSubgraphPools(
     // can filter for publicSwap too??
     const query = `
       {
-        pools: pools(first: 1000) {
+        pools: pools(first: 1000, where: { swapEnabled: true }) {
           id
           address
           poolType


### PR DESCRIPTION
I've updated the subgraph query to filter out any paused pools so that we don't have to filter them client side

I've also ensured that once we hit 1000 pools we only consider the most liquid pools.