### PR TITLE
Remove case sensitivity on some token checks + use variables in tests

### DIFF
--- a/src/pools/elementPool/elementPool.ts
+++ b/src/pools/elementPool/elementPool.ts
@@ -1,5 +1,6 @@
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as ONE } from '@ethersproject/constants';
+import { isSameAddress } from '../../utils';
 import { BigNumber as OldBigNumber, bnum } from '../../utils/bignumber';
 import {
     PoolBase,
@@ -202,7 +203,7 @@ export class ElementPool implements PoolBase {
             this.totalShares = newBalance;
         } else {
             // token is underlying in the pool
-            const T = this.tokens.find((t) => t.address === token);
+            const T = this.tokens.find((t) => isSameAddress(t.address, token));
             if (!T) throw Error('Pool does not contain this token');
             T.balance = formatFixed(newBalance, T.decimals);
         }

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -1,6 +1,6 @@
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as ONE } from '@ethersproject/constants';
-
+import { isSameAddress } from '../../utils';
 import {
     BigNumber as OldBigNumber,
     bnum,
@@ -193,7 +193,7 @@ export class MetaStablePool implements PoolBase {
             this.totalShares = newBalance;
         } else {
             // token is underlying in the pool
-            const T = this.tokens.find((t) => t.address === token);
+            const T = this.tokens.find((t) => isSameAddress(t.address, token));
             if (!T) throw Error('Pool does not contain this token');
             T.balance = formatFixed(newBalance, T.decimals);
         }

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -7,6 +7,7 @@ import {
     scale,
     ZERO,
 } from '../../utils/bignumber';
+import { isSameAddress } from '../../utils';
 import {
     PoolBase,
     PoolTypes,
@@ -175,7 +176,7 @@ export class StablePool implements PoolBase {
             this.totalShares = newBalance;
         } else {
             // token is underlying in the pool
-            const T = this.tokens.find((t) => t.address === token);
+            const T = this.tokens.find((t) => isSameAddress(t.address, token));
             if (!T) throw Error('Pool does not contain this token');
             T.balance = formatFixed(newBalance, T.decimals);
         }

--- a/src/pools/weightedPool/weightedPool.ts
+++ b/src/pools/weightedPool/weightedPool.ts
@@ -5,6 +5,7 @@ import {
     scale,
     ZERO,
 } from '../../utils/bignumber';
+import { isSameAddress } from '../../utils';
 import * as SDK from '@georgeroman/balancer-v2-pools';
 import {
     PoolBase,
@@ -170,7 +171,7 @@ export class WeightedPool implements PoolBase {
             this.totalShares = newBalance;
         } else {
             // token is underlying in the pool
-            const T = this.tokens.find((t) => t.address === token);
+            const T = this.tokens.find((t) => isSameAddress(t.address, token));
             if (!T) throw Error('Pool does not contain this token');
             T.balance = formatFixed(newBalance, T.decimals);
         }

--- a/src/routeProposal/filtering.ts
+++ b/src/routeProposal/filtering.ts
@@ -65,13 +65,11 @@ export function filterPoolsOfInterest(
         if (!newPool) return;
 
         const tokenListSet = new Set(pool.tokensList);
+        const containsTokenIn = tokenListSet.has(tokenIn.toLowerCase());
+        const containsTokenOut = tokenListSet.has(tokenOut.toLowerCase());
 
         // This is a direct pool as has both tokenIn and tokenOut
-        if (
-            (tokenListSet.has(tokenIn) && tokenListSet.has(tokenOut)) ||
-            (tokenListSet.has(tokenIn.toLowerCase()) &&
-                tokenListSet.has(tokenOut.toLowerCase()))
-        ) {
+        if (containsTokenIn && containsTokenOut) {
             newPool.setTypeForSwap(SwapPairType.Direct);
             // parsePoolPairData for Direct pools as it avoids having to loop later
             newPool.parsePoolPairData(tokenIn, tokenOut);
@@ -80,9 +78,6 @@ export function filterPoolsOfInterest(
         }
 
         if (maxPools > 1) {
-            const containsTokenIn = tokenListSet.has(tokenIn);
-            const containsTokenOut = tokenListSet.has(tokenOut);
-
             if (containsTokenIn && !containsTokenOut) {
                 tokenInPairedTokens = new Set([
                     ...tokenInPairedTokens,

--- a/test/filtersAndPaths.spec.ts
+++ b/test/filtersAndPaths.spec.ts
@@ -20,10 +20,7 @@ import subgraphPoolsLarge from './testData/testPools/subgraphPoolsLarge.json';
 import testPools from './testData/filterTestPools.json';
 import { Zero } from '@ethersproject/constants';
 import { parseFixed, BigNumber } from '@ethersproject/bignumber';
-
-const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH lower case
-const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'.toLowerCase();
-const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'.toLowerCase();
+import { DAI, USDC, WETH } from './lib/constants';
 
 describe('Tests pools filtering and path processing', () => {
     it('weighted test pools check', () => {

--- a/test/fullSwaps.spec.ts
+++ b/test/fullSwaps.spec.ts
@@ -1,5 +1,5 @@
 // npx mocha -r ts-node/register test/fullSwaps.spec.ts
-import { BigNumber, formatFixed } from '@ethersproject/bignumber';
+import { BigNumber } from '@ethersproject/bignumber';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import cloneDeep from 'lodash.clonedeep';
 import { assert } from 'chai';
@@ -11,13 +11,9 @@ import subgraphPoolsLarge from './testData/testPools/subgraphPoolsLarge.json';
 import testPools from './testData/filterTestPools.json';
 import { parseFixed } from '@ethersproject/bignumber';
 import { Zero } from '@ethersproject/constants';
+import { WETH, DAI, USDC, MKR, WBTC } from './lib/constants';
 
-const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // WETH lower case
-const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'.toLowerCase();
-const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'.toLowerCase();
 const ANT = '0x960b236a07cf122663c4303350609a66a7b288c0'; // ANT lower case
-const MKR = '0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2'; // MKR lower case
-const WBTC = '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb'.toLowerCase();
 const MKR2 = '0xef13C0c8abcaf5767160018d268f9697aE4f5375'.toLowerCase();
 const yUSD = '0xb2fdd60ad80ca7ba89b9bab3b5336c2601c020b4';
 

--- a/test/helpers.spec.ts
+++ b/test/helpers.spec.ts
@@ -12,6 +12,7 @@ import { SwapInfo, SwapTypes, SwapV2 } from '../src/types';
 import { BigNumber as OldBigNumber } from '../src/utils/bignumber';
 import testSwaps from './testData/swapsForFormatting.json';
 import { parseFixed } from '@ethersproject/bignumber';
+import { BAL, DAI, GUSD, USDC, WETH } from './lib/constants';
 
 const marketSp: OldBigNumber = new OldBigNumber(7);
 
@@ -19,24 +20,19 @@ const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
 
-const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
-
 // npx mocha -r ts-node/register test/helpers.spec.ts
 describe(`Tests for Helpers.`, () => {
     it(`Should format directhop swapExactIn`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = DAI;
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directhops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -71,18 +67,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = DAI;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.multihops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, WETH, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -123,17 +114,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = DAI;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directandmultihops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -171,16 +158,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('1', 18);
         const returnAmountConsideringFees = parseFixed('0.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = DAI;
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directhops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -215,18 +199,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = DAI;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.multihops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, WETH, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -263,17 +242,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = DAI;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directandmultihops;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -308,16 +283,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 6);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenIn = USDC;
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directhopUSDCIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-        ];
+        const expectedTokenAddresses: string[] = [USDC, DAI];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -345,16 +317,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 6);
         const returnAmountConsideringFees = parseFixed('1.9', 6);
-        const tokenIn = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenIn = USDC;
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directhopUSDCIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-        ];
+        const expectedTokenAddresses: string[] = [USDC, DAI];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -382,16 +351,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 6);
         const returnAmountConsideringFees = parseFixed('1.9', 6);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenIn = DAI;
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directhopUSDCOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, USDC];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -419,16 +385,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 6);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenIn = DAI;
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directhopUSDCOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        ];
+        const expectedTokenAddresses: string[] = [DAI, USDC];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -456,8 +419,8 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenIn = DAI;
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = [];
@@ -487,8 +450,8 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 6);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x6b175474e89094c44da98b954eedeac495271d0f';
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenIn = DAI;
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = [];
@@ -513,16 +476,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // Weth In
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = WETH;
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directhopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [WETH, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -550,20 +510,17 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // Weth In
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = WETH; // Weth In
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactIn;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directhopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            isEthSwap.wethAddress,
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [isEthSwap.wethAddress, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -591,16 +548,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xba100000625a3754423978a60c9317c58a424e3d';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // Weth Out
+        const tokenIn = BAL;
+        const tokenOut = WETH; // Weth Out
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directhopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-        ];
+        const expectedTokenAddresses: string[] = [BAL, WETH];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -628,20 +582,17 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xba100000625a3754423978a60c9317c58a424e3d';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'; // Weth Out
+        const tokenIn = BAL;
+        const tokenOut = WETH; // Weth Out
         const swapType = SwapTypes.SwapExactIn;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directhopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-            isEthSwap.wethAddress,
-        ];
+        const expectedTokenAddresses: string[] = [BAL, isEthSwap.wethAddress];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -669,16 +620,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('2', 18);
         const returnAmount = parseFixed('1', 18);
         const returnAmountConsideringFees = parseFixed('0.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = WETH;
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directhopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [WETH, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -706,20 +654,17 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('2', 18);
         const returnAmount = parseFixed('1', 18);
         const returnAmountConsideringFees = parseFixed('0.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0xba100000625a3754423978a60c9317c58a424e3d';
+        const tokenIn = WETH;
+        const tokenOut = BAL;
         const swapType = SwapTypes.SwapExactOut;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directhopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            isEthSwap.wethAddress,
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [isEthSwap.wethAddress, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -747,16 +692,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('2', 18);
         const returnAmount = parseFixed('1', 18);
         const returnAmountConsideringFees = parseFixed('0.9', 18);
-        const tokenIn = '0xba100000625a3754423978a60c9317c58a424e3d';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = BAL;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directhopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-        ];
+        const expectedTokenAddresses: string[] = [BAL, WETH];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -784,20 +726,17 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('2', 18);
         const returnAmount = parseFixed('1', 18);
         const returnAmountConsideringFees = parseFixed('0.9', 18);
-        const tokenIn = '0xba100000625a3754423978a60c9317c58a424e3d';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = BAL;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactOut;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directhopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-            isEthSwap.wethAddress,
-        ];
+        const expectedTokenAddresses: string[] = [BAL, isEthSwap.wethAddress];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -825,17 +764,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = WETH;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [WETH, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -869,20 +804,20 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = WETH;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactIn;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethIn;
 
         const expectedTokenAddresses: string[] = [
             isEthSwap.wethAddress,
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
+            GUSD,
+            BAL,
         ];
 
         const swapInfo: SwapInfo = formatSwaps(
@@ -917,17 +852,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = WETH;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethIn;
 
-        const expectedTokenAddresses: string[] = [
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [WETH, GUSD, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -962,20 +893,20 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
+        const tokenIn = WETH;
+        const tokenOut = GUSD;
         const swapType = SwapTypes.SwapExactOut;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethIn;
 
         const expectedTokenAddresses: string[] = [
             isEthSwap.wethAddress,
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
+            GUSD,
+            BAL,
         ];
 
         const swapInfo: SwapInfo = formatSwaps(
@@ -1011,17 +942,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = GUSD;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactIn;
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [GUSD, WETH, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -1055,20 +982,20 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = GUSD;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactIn;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethOut;
 
         const expectedTokenAddresses: string[] = [
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
+            GUSD,
             isEthSwap.wethAddress,
-            '0xba100000625a3754423978a60c9317c58a424e3d',
+            BAL,
         ];
 
         const swapInfo: SwapInfo = formatSwaps(
@@ -1103,17 +1030,13 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = GUSD;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactOut;
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethOut;
 
-        const expectedTokenAddresses: string[] = [
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
-            '0xba100000625a3754423978a60c9317c58a424e3d',
-        ];
+        const expectedTokenAddresses: string[] = [GUSD, WETH, BAL];
 
         const swapInfo: SwapInfo = formatSwaps(
             swapsV1Format,
@@ -1148,20 +1071,20 @@ describe(`Tests for Helpers.`, () => {
         const swapAmount = parseFixed('1', 18);
         const returnAmount = parseFixed('2', 18);
         const returnAmountConsideringFees = parseFixed('1.9', 18);
-        const tokenIn = '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd';
-        const tokenOut = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+        const tokenIn = GUSD;
+        const tokenOut = WETH;
         const swapType = SwapTypes.SwapExactOut;
         const isEthSwap = {
             isEthSwap: true,
-            wethAddress: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            wethAddress: WETH,
         };
 
         const swapsV1Format: any = testSwaps.directandmultihopsWethOut;
 
         const expectedTokenAddresses: string[] = [
-            '0x056fd409e1d7a124bd7017459dfea2f387b6d5cd',
+            GUSD,
             isEthSwap.wethAddress,
-            '0xba100000625a3754423978a60c9317c58a424e3d',
+            BAL,
         ];
 
         const swapInfo: SwapInfo = formatSwaps(

--- a/test/lbp.spec.ts
+++ b/test/lbp.spec.ts
@@ -4,6 +4,7 @@ import { JsonRpcProvider } from '@ethersproject/providers';
 import { SOR } from '../src';
 import { SwapInfo, SwapTypes, SubgraphPoolBase } from '../src/types';
 import { parseFixed } from '@ethersproject/bignumber';
+import { DAI, USDC } from './lib/constants';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
@@ -12,9 +13,6 @@ const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
 
-// const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
-const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f';
 // const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7';
 // const BPT = '0xebfed10e11dc08fcda1af1fda146945e8710f22e';
 // const RANDOM = '0x1456688345527be1f37e9e627da0837d6f08c925';

--- a/test/lib/constants.ts
+++ b/test/lib/constants.ts
@@ -1,0 +1,8 @@
+export const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'.toLowerCase();
+export const WBTC = '0xe0C9275E44Ea80eF17579d33c55136b7DA269aEb'.toLowerCase();
+export const BAL = '0xba100000625a3754423978a60c9317c58a424e3D'.toLowerCase();
+export const MKR = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2'.toLowerCase();
+export const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'.toLowerCase();
+export const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'.toLowerCase();
+export const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7'.toLowerCase();
+export const GUSD = '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd'.toLowerCase();

--- a/test/metaStablePools.spec.ts
+++ b/test/metaStablePools.spec.ts
@@ -11,6 +11,7 @@ import {
     MetaStablePool,
     MetaStablePoolPairData,
 } from '../src/pools/metaStablePool/metaStablePool';
+import { BAL, USDC, WETH } from './lib/constants';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
@@ -19,12 +20,7 @@ const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
 
-const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
-const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-// const DAI = '0x04df6e4121c27713ed22341e7c7df330f56f289b';
-// const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7';
 // const BPT = '0xebfed10e11dc08fcda1af1fda146945e8710f22e';
-const WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
 const stETH = '0xae7ab96520de3a18e5e111b5eaab095312d7fe84';
 const randomETH = '0x42d6622dece394b54999fbd73d108123806f6a18';
 // const PTSP = '0x5f304f6cf88dc76b414f301e05adfb5a429e8b67';

--- a/test/routeProposer.spec.ts
+++ b/test/routeProposer.spec.ts
@@ -1,11 +1,11 @@
 // npx mocha -r ts-node/register test/wrapper.spec.ts
 require('dotenv').config();
+import { parseFixed } from '@ethersproject/bignumber';
 import { expect } from 'chai';
 
 import { RouteProposer } from '../src/routeProposal';
-import { BigNumber } from '../src/utils/bignumber';
 import { SwapTypes, SubgraphPoolBase, SwapOptions } from '../src/types';
-import { parseFixed } from '@ethersproject/bignumber';
+import { DAI, WETH } from './lib/constants';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
@@ -21,8 +21,8 @@ describe(`RouteProposer.`, () => {
             pools: SubgraphPoolBase[];
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
-        const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenIn = WETH;
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
 
         const routeProposer = new RouteProposer();

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/pools/stablePool/stablePool';
 import { BPTForTokensZeroPriceImpact } from '../src/frontendHelpers/stableHelpers';
 import { parseFixed } from '@ethersproject/bignumber';
+import { BAL, DAI, USDC, USDT } from './lib/constants';
 
 const gasPrice = parseFixed('30', 9);
 const maxPools = 4;
@@ -18,13 +19,6 @@ const chainId = 1;
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
 );
-
-const BAL = '0xba100000625a3754423978a60c9317c58a424e3d';
-const USDC = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const DAI = '0x6b175474e89094c44da98b954eedeac495271d0f';
-const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7';
-const BPT = '0xebfed10e11dc08fcda1af1fda146945e8710f22e';
-const RANDOM = '0x1456688345527be1f37e9e627da0837d6f08c925';
 
 // npx mocha -r ts-node/register test/stablePools.spec.ts
 describe(`Tests for Stable Pools.`, () => {

--- a/test/swapCostCalculator.spec.ts
+++ b/test/swapCostCalculator.spec.ts
@@ -2,6 +2,7 @@
 import { expect } from 'chai';
 import { BigNumber, formatFixed } from '@ethersproject/bignumber';
 import { calculateTotalSwapCost, SwapCostCalculator } from '../src/swapCost';
+import { DAI, MKR, USDC, WETH } from './lib/constants';
 
 describe('calculateTotalSwapCost', () => {
     it('should return correct total swap cost', async () => {
@@ -36,10 +37,6 @@ describe('calculateTotalSwapCost', () => {
 });
 
 describe('Test SwapCostCalculator', () => {
-    const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
-    const WETH = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
-    const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
-
     describe('convertGasCostToToken', () => {
         it("Should return 0 if CoinGecko doesn't recognise token", async () => {
             const gasPriceWei = BigNumber.from('30000000000');
@@ -87,7 +84,6 @@ describe('Test SwapCostCalculator', () => {
         it('Example of full call with MKR & 30GWEI Gas Price', async () => {
             const gasPriceWei = BigNumber.from('30000000000');
             const swapGas = BigNumber.from('100000');
-            const MKR = '0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2';
 
             const cost = await new SwapCostCalculator(1).convertGasCostToToken(
                 MKR,

--- a/test/wrapper.spec.ts
+++ b/test/wrapper.spec.ts
@@ -11,8 +11,7 @@ import {
     PoolFilter,
     SubgraphPoolBase,
 } from '../src/types';
-
-const WETHADDR = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+import { DAI, USDC, WETH } from './lib/constants';
 
 const provider = new JsonRpcProvider(
     `https://mainnet.infura.io/v3/${process.env.INFURA}`
@@ -30,7 +29,7 @@ describe(`Tests for wrapper class.`, () => {
 
     it(`Should return no swaps when pools not retrieved.`, async () => {
         const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = Zero;
         const sor = new SOR(provider, chainId, poolsUrl);
@@ -51,7 +50,7 @@ describe(`Tests for wrapper class.`, () => {
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
         const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
@@ -99,7 +98,7 @@ describe(`Tests for wrapper class.`, () => {
         const pools = poolsFromFile.pools;
 
         const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
@@ -139,7 +138,7 @@ describe(`Tests for wrapper class.`, () => {
         const pools = poolsFromFile.pools;
 
         const tokenIn = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
@@ -175,7 +174,7 @@ describe(`Tests for wrapper class.`, () => {
         const pools = poolsFromFile.pools;
 
         const tokenIn = AddressZero;
-        const tokenOut = '0x6b175474e89094c44da98b954eedeac495271d0f';
+        const tokenOut = DAI;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
@@ -192,11 +191,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddresses = [
-            AddressZero,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-        ];
+        const expectedTokenAddresses = [AddressZero, DAI, USDC];
 
         expect(expectedTokenAddresses).to.deep.eq(swapInfo.tokenAddresses);
         expect(swapInfo.returnAmount.gt(0)).to.be.true;
@@ -216,9 +211,9 @@ describe(`Tests for wrapper class.`, () => {
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
 
-        const tokenInWeth = WETHADDR;
+        const tokenInWeth = WETH;
         const tokenInEth = AddressZero;
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 18);
 
@@ -235,11 +230,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesEth = [
-            tokenInEth,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            tokenOut,
-        ];
+        const expectedTokenAddressesEth = [tokenInEth, DAI, tokenOut];
 
         expect(expectedTokenAddressesEth).to.deep.eq(
             swapInfoEth.tokenAddresses
@@ -256,11 +247,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesWeth = [
-            tokenInWeth,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            tokenOut,
-        ];
+        const expectedTokenAddressesWeth = [tokenInWeth, DAI, tokenOut];
 
         // Swaps/amts, etc should be same. Token list should be different
         expect(expectedTokenAddressesWeth).to.deep.eq(swapInfo.tokenAddresses);
@@ -288,8 +275,8 @@ describe(`Tests for wrapper class.`, () => {
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
 
-        const tokenIn = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-        const tokenOutWeth = WETHADDR;
+        const tokenIn = USDC;
+        const tokenOutWeth = WETH;
         const tokenOutEth = AddressZero;
         const swapType = SwapTypes.SwapExactIn;
         const swapAmt = parseFixed('0.1', 6);
@@ -324,7 +311,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesWeth = [tokenIn, WETHADDR];
+        const expectedTokenAddressesWeth = [tokenIn, WETH];
 
         // Swaps/amts, etc should be same. Token list should be different
         expect(expectedTokenAddressesWeth).to.deep.eq(swapInfo.tokenAddresses);
@@ -351,9 +338,9 @@ describe(`Tests for wrapper class.`, () => {
             pools: SubgraphPoolBase[];
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
-        const tokenInWeth = WETHADDR;
+        const tokenInWeth = WETH;
         const tokenInEth = AddressZero;
-        const tokenOut = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+        const tokenOut = USDC;
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('0.1', 6);
 
@@ -370,11 +357,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesEth = [
-            tokenInEth,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            tokenOut,
-        ];
+        const expectedTokenAddressesEth = [tokenInEth, DAI, tokenOut];
 
         expect(expectedTokenAddressesEth).to.deep.eq(
             swapInfoEth.tokenAddresses
@@ -391,11 +374,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesWeth = [
-            tokenInWeth,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            tokenOut,
-        ];
+        const expectedTokenAddressesWeth = [tokenInWeth, DAI, tokenOut];
 
         // Swaps/amts, etc should be same. Token list should be different
         expect(expectedTokenAddressesWeth).to.deep.eq(swapInfo.tokenAddresses);
@@ -418,8 +397,8 @@ describe(`Tests for wrapper class.`, () => {
             pools: SubgraphPoolBase[];
         } = require('./testData/testPools/subgraphPoolsSmallWithTrade.json');
         const pools = poolsFromFile.pools;
-        const tokenIn = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-        const tokenOutWeth = WETHADDR;
+        const tokenIn = USDC;
+        const tokenOutWeth = WETH;
         const tokenOutEth = AddressZero;
         const swapType = SwapTypes.SwapExactOut;
         const swapAmt = parseFixed('0.1', 18);
@@ -437,11 +416,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesEth = [
-            tokenIn,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            AddressZero,
-        ];
+        const expectedTokenAddressesEth = [tokenIn, DAI, AddressZero];
 
         expect(expectedTokenAddressesEth).to.deep.eq(
             swapInfoEth.tokenAddresses
@@ -458,11 +433,7 @@ describe(`Tests for wrapper class.`, () => {
             { gasPrice, maxPools }
         );
 
-        const expectedTokenAddressesWeth = [
-            tokenIn,
-            '0x6b175474e89094c44da98b954eedeac495271d0f',
-            WETHADDR,
-        ];
+        const expectedTokenAddressesWeth = [tokenIn, DAI, WETH];
 
         // Swaps/amts, etc should be same. Token list should be different
         expect(expectedTokenAddressesWeth).to.deep.eq(swapInfo.tokenAddresses);


### PR DESCRIPTION
I've relaxed some conditions when testing for token addresses to make them case insensitive.

We've also got a ton of token addresses in the tests to I've switched to storing them in variables. We should avoid having duplicated string literal addresses where possible.