### PR TITLE
Removes unused parameter.

### DIFF
--- a/src/router/helpersClass.ts
+++ b/src/router/helpersClass.ts
@@ -9,7 +9,6 @@ import { getOutputAmountSwap } from '../pools';
 import { INFINITESIMAL } from '../config';
 import {
     NewPath,
-    PoolDictionary,
     SwapTypes,
     PoolBase,
     PoolPairBase,
@@ -33,7 +32,6 @@ export function getHighestLimitAmountsForPaths(
 }
 
 export function getEffectivePriceSwapForPath(
-    pools: PoolDictionary,
     path: NewPath,
     swapType: SwapTypes,
     amount: OldBigNumber,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,12 +1,11 @@
 import { BigNumber as OldBigNumber, bnum, ZERO } from '../utils/bignumber';
 import { getHighestLimitAmountsForPaths } from './helpersClass';
 import { formatSwaps, optimizeSwapAmounts } from './sorClass';
-import { NewPath, PoolDictionary, Swap, SwapTypes } from '../types';
+import { NewPath, Swap, SwapTypes } from '../types';
 import { BigNumber, formatFixed } from '@ethersproject/bignumber';
 import { Zero } from '@ethersproject/constants';
 
 export const getBestPaths = (
-    pools: PoolDictionary,
     paths: NewPath[],
     swapType: SwapTypes,
     totalSwapAmount: BigNumber,
@@ -53,7 +52,6 @@ export const getBestPaths = (
 
     const [bestPaths, bestSwapAmounts, bestTotalReturnConsideringFees] =
         optimizeSwapAmounts(
-            pools,
             paths,
             swapType,
             bnum(formatFixed(totalSwapAmount, inputDecimals)),

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -16,7 +16,6 @@ import {
     SwapInfo,
     SwapTypes,
     NewPath,
-    PoolDictionary,
     PoolFilter,
     Swap,
     SubgraphPoolBase,
@@ -161,14 +160,13 @@ export class SOR {
     ): Promise<SwapInfo> {
         if (pools.length === 0) return cloneDeep(EMPTY_SWAPINFO);
 
-        const { pools: poolsOfInterest, paths } =
-            this.routeProposer.getCandidatePaths(
-                tokenIn,
-                tokenOut,
-                swapType,
-                pools,
-                swapOptions
-            );
+        const paths = this.routeProposer.getCandidatePaths(
+            tokenIn,
+            tokenOut,
+            swapType,
+            pools,
+            swapOptions
+        );
 
         if (paths.length == 0) return { ...EMPTY_SWAPINFO };
 
@@ -197,7 +195,6 @@ export class SOR {
         // Returns list of swaps
         const [swaps, total, marketSp, totalConsideringFees] =
             this.getBestPaths(
-                poolsOfInterest,
                 paths,
                 swapAmount,
                 swapType,
@@ -227,7 +224,6 @@ export class SOR {
      * Find optimal routes for trade from given candidate paths
      */
     private getBestPaths(
-        pools: PoolDictionary,
         paths: NewPath[],
         swapAmount: BigNumber,
         swapType: SwapTypes,
@@ -245,7 +241,6 @@ export class SOR {
                 : [tokenOutDecimals, tokenInDecimals];
 
         const [swaps, total, marketSp, totalConsideringFees] = getBestPaths(
-            cloneDeep(pools),
             paths,
             swapType,
             swapAmount,

--- a/test/filtersAndPaths.spec.ts
+++ b/test/filtersAndPaths.spec.ts
@@ -687,7 +687,6 @@ describe('Tests pools filtering and path processing', () => {
         assert.equal(pathsWithLimits[1].limitAmount.toString(), '300000000');
 
         const [swaps, total, marketSp] = getBestPaths(
-            cloneDeep(poolsOfInterestDictionary), // Need to keep original pools for cache
             pathsWithLimits,
             SwapTypes.SwapExactIn,
             parseFixed('1', 6),
@@ -795,7 +794,6 @@ describe('Tests pools filtering and path processing', () => {
         assert.equal(paths[1].limitAmount.toString(), '228989976869699350000');
 
         const [swaps, total, marketSp] = getBestPaths(
-            cloneDeep(poolsOfInterestDictionary), // Need to keep original pools for cache
             paths,
             SwapTypes.SwapExactOut,
             parseFixed('1', 18),


### PR DESCRIPTION
There was an unused PoolDictionary being passed around. `getBestPaths` and `optimizeSwapAmounts` both had it as a param but it wasn't actually being used as far as I can see. I've removed it completely which should make the code clearer.