### PR TITLE
Fix amp scaling

### DIFF
--- a/src/frontendHelpers/stableHelpers.ts
+++ b/src/frontendHelpers/stableHelpers.ts
@@ -17,7 +17,7 @@ export function BPTForTokensZeroPriceImpact(
     decimals: number[],
     amounts: OldBigNumber[], // This has to have the same lenght as allBalances
     bptTotalSupply: OldBigNumber,
-    amp: OldBigNumber
+    amp: BigNumber
 ): OldBigNumber {
     if (allBalances.length != amounts.length)
         throw 'allBalances and amounts have to have same length';

--- a/src/pools/metaStablePool/metaStableMath.ts
+++ b/src/pools/metaStablePool/metaStableMath.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from '@ethersproject/bignumber';
+import { BigNumber, formatFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as EONE } from '@ethersproject/constants';
 import {
     BigNumber as OldBigNumber,
@@ -34,7 +34,10 @@ export function _invariant(
     }
     let prevInv = ZERO;
     let inv = sum;
-    const ampTimesNpowN = bnum(amp.toString()).times(totalCoins ** totalCoins); // A*n^n
+
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const ampAdjusted = bnum(formatFixed(amp, 3));
+    const ampTimesNpowN = ampAdjusted.times(totalCoins ** totalCoins); // A*n^n
 
     for (let i = 0; i < 255; i++) {
         let P_D = bnum(totalCoins).times(balances[0]);

--- a/src/pools/metaStablePool/metaStableMath.ts
+++ b/src/pools/metaStablePool/metaStableMath.ts
@@ -248,7 +248,8 @@ export function _solveAnalyticalBalance(
     n_pow_n: OldBigNumber,
     p: OldBigNumber
 ): OldBigNumber {
-    const oldBN_amp = bnum(amp.toString());
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const oldBN_amp = bnum(formatFixed(amp, 3));
 
     //Round up p
     p = p.times(inv).div(oldBN_amp.times(n_pow_n).times(n_pow_n));
@@ -297,7 +298,9 @@ export function _poolDerivatives(
     }
     const x = balances[tokenIndexIn];
     const y = balances[tokenIndexOut];
-    const a = bnum(amp.toString()).times(totalCoins ** totalCoins); // = ampTimesNpowN
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const ampAdjusted = bnum(formatFixed(amp, 3));
+    const a = ampAdjusted.times(totalCoins ** totalCoins); // = ampTimesNpowN
     const b = S.minus(D).times(a).plus(D);
     const twoaxy = bnum(2).times(a).times(x).times(y);
     const partial_x = twoaxy.plus(a.times(y).times(y)).plus(b.times(y));

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -151,7 +151,7 @@ export class MetaStablePool implements PoolBase {
         return bnum(
             formatFixed(
                 poolPairData.balanceOut.mul(poolPairData.amp),
-                poolPairData.decimalsOut
+                poolPairData.decimalsOut + MetaStablePool.AMP_DECIMALS
             )
         );
     }

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -46,10 +46,10 @@ export class MetaStablePool implements PoolBase {
     totalShares: BigNumber;
     tokens: MetaStablePoolToken[];
     tokensList: string[];
-    AMP_PRECISION = BigNumber.from('1000');
     MAX_IN_RATIO = parseFixed('0.3', 18);
     MAX_OUT_RATIO = parseFixed('0.3', 18);
-    ampAdjusted: BigNumber;
+
+    static AMP_DECIMALS = 3;
 
     static fromPool(pool: SubgraphPoolBase): MetaStablePool {
         if (!pool.amp) throw new Error('MetaStablePool missing amp factor');
@@ -75,12 +75,11 @@ export class MetaStablePool implements PoolBase {
     ) {
         this.id = id;
         this.address = address;
-        this.amp = parseFixed(amp, 0);
+        this.amp = parseFixed(amp, MetaStablePool.AMP_DECIMALS);
         this.swapFee = parseFixed(swapFee, 18);
         this.totalShares = parseFixed(totalShares, 18);
         this.tokens = tokens;
         this.tokensList = tokensList;
-        this.ampAdjusted = this.amp.mul(this.AMP_PRECISION);
     }
 
     setTypeForSwap(type: SwapPairType): void {
@@ -213,7 +212,7 @@ export class MetaStablePool implements PoolBase {
             );
 
             const amt = SDK.StableMath._calcOutGivenIn(
-                bnum(this.ampAdjusted.toString()),
+                bnum(this.amp.toString()),
                 poolPairData.allBalancesScaled.map((balance) =>
                     bnum(balance.toString())
                 ),
@@ -250,7 +249,7 @@ export class MetaStablePool implements PoolBase {
             );
 
             const amt = SDK.StableMath._calcInGivenOut(
-                bnum(this.ampAdjusted.toString()),
+                bnum(this.amp.toString()),
                 poolPairData.allBalancesScaled.map((balance) =>
                     bnum(balance.toString())
                 ),

--- a/src/pools/stablePool/stableMath.ts
+++ b/src/pools/stablePool/stableMath.ts
@@ -34,7 +34,10 @@ export function _invariant(
     }
     let prevInv = ZERO;
     let inv = sum;
-    const ampTimesNpowN = bnum(amp.toString()).times(totalCoins ** totalCoins); // A*n^n
+
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const ampAdjusted = bnum(formatFixed(amp, 3));
+    const ampTimesNpowN = ampAdjusted.times(totalCoins ** totalCoins); // A*n^n
 
     for (let i = 0; i < 255; i++) {
         let P_D = bnum(totalCoins).times(balances[0]);

--- a/src/pools/stablePool/stableMath.ts
+++ b/src/pools/stablePool/stableMath.ts
@@ -308,7 +308,8 @@ export function _solveAnalyticalBalance(
     n_pow_n: OldBigNumber,
     p: OldBigNumber
 ): OldBigNumber {
-    const oldBN_amp = bnum(amp.toString());
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const oldBN_amp = bnum(formatFixed(amp, 3));
     //Round up p
     p = p.times(inv).div(oldBN_amp.times(n_pow_n).times(n_pow_n));
     //Round down b
@@ -356,7 +357,9 @@ export function _poolDerivatives(
     }
     const x = balances[tokenIndexIn];
     const y = balances[tokenIndexOut];
-    const a = bnum(amp.toString()).times(totalCoins ** totalCoins); // = ampTimesNpowN
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const ampAdjusted = bnum(formatFixed(amp, 3));
+    const a = ampAdjusted.times(totalCoins ** totalCoins); // = ampTimesNpowN
     const b = S.minus(D).times(a).plus(D);
     const twoaxy = bnum(2).times(a).times(x).times(y);
     const partial_x = twoaxy.plus(a.times(y).times(y)).plus(b.times(y));
@@ -407,7 +410,9 @@ export function _poolDerivativesBPT(
         }
     }
     const x = balances[tokenIndexIn];
-    const alpha = bnum(amp.toString()).times(totalCoins ** totalCoins); // = ampTimesNpowN
+    // amp is passed as an ethers bignumber while maths uses bignumber.js
+    const ampAdjusted = bnum(formatFixed(amp, 3));
+    const alpha = ampAdjusted.times(totalCoins ** totalCoins); // = ampTimesNpowN
     const beta = alpha.times(S);
     const gamma = ONE.minus(alpha);
     const partial_x = bnum(2)

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -139,7 +139,7 @@ export class StablePool implements PoolBase {
         return bnum(
             formatFixed(
                 poolPairData.balanceOut.mul(poolPairData.amp),
-                poolPairData.decimalsOut
+                poolPairData.decimalsOut + StablePool.AMP_DECIMALS
             )
         );
     }

--- a/src/pools/stablePool/stablePool.ts
+++ b/src/pools/stablePool/stablePool.ts
@@ -47,10 +47,10 @@ export class StablePool implements PoolBase {
     totalShares: BigNumber;
     tokens: StablePoolToken[];
     tokensList: string[];
-    AMP_PRECISION = BigNumber.from('1000');
     MAX_IN_RATIO = parseFixed('0.3', 18);
     MAX_OUT_RATIO = parseFixed('0.3', 18);
-    ampAdjusted: BigNumber;
+
+    static AMP_DECIMALS = 3;
 
     static fromPool(pool: SubgraphPoolBase): StablePool {
         if (!pool.amp) throw new Error('StablePool missing amp factor');
@@ -76,12 +76,11 @@ export class StablePool implements PoolBase {
     ) {
         this.id = id;
         this.address = address;
-        this.amp = parseFixed(amp, 0);
+        this.amp = parseFixed(amp, StablePool.AMP_DECIMALS);
         this.swapFee = parseFixed(swapFee, 18);
         this.totalShares = parseFixed(totalShares, 18);
         this.tokens = tokens;
         this.tokensList = tokensList;
-        this.ampAdjusted = this.amp.mul(this.AMP_PRECISION);
     }
 
     setTypeForSwap(type: SwapPairType): void {
@@ -193,7 +192,7 @@ export class StablePool implements PoolBase {
             const amtScaled = scale(amount, 18);
 
             const amt = SDK.StableMath._calcOutGivenIn(
-                bnum(this.ampAdjusted.toString()),
+                bnum(this.amp.toString()),
                 poolPairData.allBalancesScaled.map((balance) =>
                     bnum(balance.toString())
                 ),
@@ -225,7 +224,7 @@ export class StablePool implements PoolBase {
             const amtScaled = scale(amount, 18);
 
             const amt = SDK.StableMath._calcInGivenOut(
-                bnum(this.ampAdjusted.toString()),
+                bnum(this.amp.toString()),
                 poolPairData.allBalancesScaled.map((balance) =>
                     bnum(balance.toString())
                 ),

--- a/test/stablePools.spec.ts
+++ b/test/stablePools.spec.ts
@@ -334,7 +334,7 @@ describe(`Tests for Stable Pools.`, () => {
     context('stable helpers', () => {
         it('should test BPTForTokensZeroPriceImpact for 0.1% single token add', () => {
             const allBalances = [bnum(1000e18), bnum(1000e18), bnum(1000e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(1e18), bnum(0), bnum(0)];
             const bptTotalSupply = bnum(3000e18);
             const decimals = [18, 18, 18];
@@ -352,7 +352,7 @@ describe(`Tests for Stable Pools.`, () => {
 
         it('should test BPTForTokensZeroPriceImpact for 1% single token add', () => {
             const allBalances = [bnum(1000e18), bnum(1000e18), bnum(1000e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(10e18), bnum(0), bnum(0)];
             const bptTotalSupply = bnum(3000e18);
             const decimals = [18, 18, 18];
@@ -370,7 +370,7 @@ describe(`Tests for Stable Pools.`, () => {
 
         it('should test BPTForTokensZeroPriceImpact for 10% single token add', () => {
             const allBalances = [bnum(1000e18), bnum(1000e18), bnum(1000e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(100e18), bnum(0), bnum(0)];
             const bptTotalSupply = bnum(3000e18);
             const decimals = [18, 18, 18];
@@ -388,7 +388,7 @@ describe(`Tests for Stable Pools.`, () => {
 
         it('should test BPTForTokensZeroPriceImpact for proportional add', () => {
             const allBalances = [bnum(1000e18), bnum(1000e18), bnum(1000e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(1e18), bnum(1e18), bnum(1e18)];
             const bptTotalSupply = bnum(3000e18);
             const decimals = [18, 18, 18];
@@ -406,7 +406,7 @@ describe(`Tests for Stable Pools.`, () => {
 
         it('should test BPTForTokensZeroPriceImpact for single token add + uneven pool', () => {
             const allBalances = [bnum(2000e18), bnum(1000e18), bnum(1000e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(1e18), bnum(0), bnum(0)];
             const bptTotalSupply = bnum(4000e18);
             const decimals = [18, 18, 18];
@@ -424,7 +424,7 @@ describe(`Tests for Stable Pools.`, () => {
 
         it('should test BPTForTokensZeroPriceImpact for single token add + VERY uneven pool', () => {
             const allBalances = [bnum(2000e18), bnum(100e18), bnum(100e18)];
-            const amp = bnum(500);
+            const amp = parseFixed('500', 3);
             const amounts = [bnum(1e18), bnum(0), bnum(0)];
             const bptTotalSupply = bnum(2200e18);
             const decimals = [18, 18, 18];
@@ -446,7 +446,7 @@ describe(`Tests for Stable Pools.`, () => {
                 bnum('1000005155543154'),
                 bnum('1000000822928777'),
             ];
-            const amp = bnum(2000);
+            const amp = parseFixed('2000', 3);
             const amounts = [
                 bnum('9654961595845215917881'),
                 bnum('9655042958'),


### PR DESCRIPTION
`StablePool.amp` was expecting to be passed scaled as to be an integer whereas it was being passed as a decimal resulting in issues.

I've accounted for this and perform the appropriate scaling when passing this value into the maths which expects a decimal.