### PR TITLE
John/sor 24 getpathsusinglinearpools using token

### DIFF
--- a/src/poolCaching/onchainData.ts
+++ b/src/poolCaching/onchainData.ts
@@ -69,7 +69,7 @@ export async function getOnChainBalances(
                 pool.address,
                 'getSwapFeePercentage'
             );
-        } else if (pool.poolType === 'Element') {
+        } else if (pool.poolType === 'Element' || pool.poolType === 'Linear') {
             multiPool.call(`${pool.id}.swapFee`, pool.address, 'percentFee');
         }
     });

--- a/src/pools/linearPool/linearPool.ts
+++ b/src/pools/linearPool/linearPool.ts
@@ -198,7 +198,7 @@ export class LinearPool implements PoolBase {
                     .times(bnum(this.ALMOST_ONE.toString()))
                     .div(bnum(ONE.toString()));
                 return limit;
-            } else throw Error('LinearPool does not support TokenToToken');
+            } else return bnum(0); // LinearPool does not support TokenToToken
         } else {
             if (linearPoolPairData.pairType === PairTypes.TokenToBpt) {
                 const limit = bnum(
@@ -216,7 +216,7 @@ export class LinearPool implements PoolBase {
                         .toString()
                 );
                 return scale(limit, -poolPairData.decimalsOut);
-            } else throw Error('LinearPool does not support TokenToToken');
+            } else return bnum(0); // LinearPool does not support TokenToToken
         }
     }
 
@@ -242,7 +242,7 @@ export class LinearPool implements PoolBase {
             return this._exactTokenInForBPTOut(poolPairData, amount, exact);
         } else if (poolPairData.pairType === PairTypes.BptToToken) {
             return this._exactBPTInForTokenOut(poolPairData, amount, exact);
-        } else throw Error('LinearPool does not support TokenToToken');
+        } else return bnum(0); // LinearPool does not support TokenToToken
     }
 
     _exactTokenInForBPTOut(
@@ -315,7 +315,7 @@ export class LinearPool implements PoolBase {
             return this._tokenInForExactBPTOut(poolPairData, amount, exact);
         } else if (poolPairData.pairType === PairTypes.BptToToken) {
             return this._BPTInForExactTokenOut(poolPairData, amount, exact);
-        } else throw Error('LinearPool does not support TokenToToken');
+        } else return bnum(0); // LinearPool does not support TokenToToken
     }
 
     _tokenInForExactBPTOut(

--- a/src/routeProposal/filtering.ts
+++ b/src/routeProposal/filtering.ts
@@ -242,18 +242,27 @@ export function getPathsUsingLinearPools(
     )
         return [];
 
-    // Create a new dictionary containing all Linear pools
-    const linearPoolsDictByMain: PoolDictionaryByMain = {};
+    // Finds linear pool containing tokenIn/Out
+    // This is currently picking first matching pool as we expect a specific deployment setup
+    // Could be changed to find most liquid
+    let linearPoolIn, linearPoolOut;
     for (const id in poolsAllDict) {
         if (poolsAllDict[id].poolType === PoolTypes.Linear) {
-            linearPoolsDictByMain[poolsAllDict[id].tokensList[0]] =
-                poolsAllDict[id]; // TO DO - This should be referncing main token. Waiting to see Subgraph schema before this is finalised
+            if (
+                !linearPoolIn &&
+                poolsAllDict[id].tokensList.includes(tokenIn.toLowerCase())
+            ) {
+                linearPoolIn = poolsAllDict[id];
+            } else if (
+                !linearPoolOut &&
+                poolsAllDict[id].tokensList.includes(tokenOut.toLowerCase())
+            ) {
+                linearPoolOut = poolsAllDict[id];
+            }
         }
     }
 
     const pathsUsingLinear: NewPath[] = [];
-    const linearPoolIn = linearPoolsDictByMain[tokenIn];
-    const linearPoolOut = linearPoolsDictByMain[tokenOut];
 
     // If neither of tokenIn and tokenOut have linear pools, return an empty array.
     if (!linearPoolIn && !linearPoolOut) return [];

--- a/src/router/sorClass.ts
+++ b/src/router/sorClass.ts
@@ -40,7 +40,6 @@ export const optimizeSwapAmounts = (
         bnum(formatFixed(amount, inputDecimals))
     );
     for (let b = initialNumPaths; b <= paths.length; b++) {
-        console.log('starting search with ', b, 'paths');
         if (b != initialNumPaths) {
             // We already had a previous iteration and are adding another pool this new iteration
             // swapAmounts.push(ONE); // Initialize new swapAmount with 1 wei to
@@ -127,10 +126,6 @@ export const optimizeSwapAmounts = (
         if (totalNumberOfPools >= maxPools) break;
     }
 
-    console.log(
-        'bestTotalReturnConsideringFees:',
-        bestTotalReturnConsideringFees.toString()
-    );
     // 0 swap amounts can occur due to rounding errors but we don't want to pass those on so filter out
     bestPaths = bestPaths.filter((_, i) => !bestSwapAmounts[i].isZero());
     bestSwapAmounts = bestSwapAmounts.filter(
@@ -226,19 +221,6 @@ export const formatSwaps = (
     // calculated with the EVM maths so the return is exactly what the user will get
     // after executing the transaction (given there are no front-runners)
 
-    // TO DO
-    console.log('\nPaths and swap amounts have been chosen now');
-    console.log('Number of paths: ', bestPaths.length);
-    for (let i = 0; i < bestPaths.length; i++) {
-        console.log('Length of path', i, ':', bestPaths[i].pools.length);
-        for (let j = 0; j < bestPaths[i].pools.length; j++) {
-            console.log('pool address:', bestPaths[i].pools[j].address);
-        }
-    }
-
-    console.log(`!!!!!!! bestSwapAmounts`);
-    console.log(JSON.stringify(bestSwapAmounts));
-
     bestPaths.forEach((path, i) => {
         const swapAmount = bestSwapAmounts[i];
 
@@ -283,8 +265,6 @@ export const formatSwaps = (
                 pathSwaps.push(swap);
             }
             returnAmount = amounts[n];
-            console.log('i: ', i, 'amounts: ', amounts.toString());
-            console.log('returnAmount: ', returnAmount.toString());
         } else {
             for (let i = 0; i < n; i++) {
                 amounts.unshift(

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -206,8 +206,6 @@ export class SOR {
                 swapOptions.maxPools
             );
 
-        console.log('swaps', swaps);
-
         const swapInfo = formatSwaps(
             swaps,
             swapType,

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -436,92 +436,142 @@ describe('linear pool tests', () => {
     });
 
     context('SOR Full Swaps', () => {
-        it('DAI>USDC, SwapExactIn', async () => {
-            const returnAmount = await testFullSwap(
-                DAI.address,
-                USDC.address,
-                SwapTypes.SwapExactIn,
-                parseFixed('25', DAI.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('25631282');
+        context('Stable Swaps', () => {
+            it('DAI>USDC, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    DAI.address,
+                    USDC.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('25', DAI.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('25631282');
+            });
+
+            it('DAI>USDC, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    DAI.address,
+                    USDC.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('27', USDC.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('26335005495898592574');
+            });
+
+            it('USDC>DAI, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    USDC.address,
+                    DAI.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('270', USDC.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('263139420004032600258');
+            });
+
+            it('USDC>DAI, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    USDC.address,
+                    DAI.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('7777', DAI.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('7979762223'); // Confirmed by Sergio
+            });
         });
 
-        it('DAI>USDC, SwapExactOut', async () => {
-            const returnAmount = await testFullSwap(
-                DAI.address,
-                USDC.address,
-                SwapTypes.SwapExactOut,
-                parseFixed('27', USDC.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('26335005495898592574');
+        context('Stable <> Token paired with WETH', () => {
+            it('USDC>BAL, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    USDC.address,
+                    BAL.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('7.21', USDC.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('652413919893769122');
+            });
+
+            it('BAL>DAI, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    BAL.address,
+                    DAI.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('321.123', BAL.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('3320451170714139189569');
+            });
+
+            it('USDC>BAL, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    USDC.address,
+                    BAL.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('0.652413919893769122', BAL.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('7210002');
+            });
+
+            it('BAL>DAI, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    BAL.address,
+                    DAI.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('3320.451170714139189569', DAI.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('321122999999986750182');
+            });
         });
 
-        it('USDC>DAI, SwapExactIn', async () => {
-            const returnAmount = await testFullSwap(
-                USDC.address,
-                DAI.address,
-                SwapTypes.SwapExactIn,
-                parseFixed('270', USDC.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('263139420004032600258');
-        });
+        context('Relayer Routes', () => {
+            it('DAI>staBAL3, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    DAI.address,
+                    staBAL3.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('1', DAI.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('946927175843694145');
+            });
 
-        it('USDC>DAI, SwapExactOut', async () => {
-            const returnAmount = await testFullSwap(
-                USDC.address,
-                DAI.address,
-                SwapTypes.SwapExactOut,
-                parseFixed('7777', DAI.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('7979762223'); // Confirmed by Sergio
-        });
+            it('USDC>staBAL3, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    USDC.address,
+                    staBAL3.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('1', staBAL3.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('1083149');
+            });
 
-        it('DAI>staBAL3, SwapExactIn', async () => {
-            const returnAmount = await testFullSwap(
-                DAI.address,
-                staBAL3.address,
-                SwapTypes.SwapExactIn,
-                parseFixed('1', DAI.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('946927175843694145');
-        });
+            it('staBAL3>USDC, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    staBAL3.address,
+                    USDC.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('1', staBAL3.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('1082280');
+            });
 
-        it('USDC>staBAL3, SwapExactOut', async () => {
-            const returnAmount = await testFullSwap(
-                USDC.address,
-                staBAL3.address,
-                SwapTypes.SwapExactOut,
-                parseFixed('1', staBAL3.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('1083149');
-        });
-
-        it('staBAL3>USDC, SwapExactIn', async () => {
-            const returnAmount = await testFullSwap(
-                staBAL3.address,
-                USDC.address,
-                SwapTypes.SwapExactIn,
-                parseFixed('1', staBAL3.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('1082280');
-        });
-
-        it('staBAL3>DAI, SwapExactOut', async () => {
-            const returnAmount = await testFullSwap(
-                staBAL3.address,
-                DAI.address,
-                SwapTypes.SwapExactOut,
-                parseFixed('1', DAI.decimals),
-                smallLinear.pools
-            );
-            expect(returnAmount).to.eq('947685172351949208');
+            it('staBAL3>DAI, SwapExactOut', async () => {
+                const returnAmount = await testFullSwap(
+                    staBAL3.address,
+                    DAI.address,
+                    SwapTypes.SwapExactOut,
+                    parseFixed('1', DAI.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('947685172351949208');
+            });
         });
     });
 });
@@ -600,7 +650,8 @@ async function testFullSwap(
         totalSwapAmount.toString(),
         'Total From SwapInfo Should Equal Swap Amount.'
     );
-
+    console.log(swapInfo.swaps);
+    console.log(swapInfo.tokenAddresses);
     console.log(`Return: ${swapInfo.returnAmount.toString()}`);
     console.log(
         `ReturnFees: ${swapInfo.returnAmountConsideringFees.toString()}`

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -31,6 +31,7 @@ import {
     TestToken,
     MKR,
     GUSD,
+    WETH,
 } from './lib/constants';
 
 // Single Linear pool DAI/aDAI/bDAI
@@ -65,20 +66,26 @@ describe('linear pool tests', () => {
     });
 
     context('limit amounts', () => {
-        it(`getLimitAmountSwap, token to token should throw error`, async () => {
+        it(`getLimitAmountSwap, token to token should return 0`, async () => {
             const tokenIn = DAI.address;
             const tokenOut = aDAI.address;
             const poolSG = cloneDeep(singleLinear);
             const pool = LinearPool.fromPool(poolSG.pools[0]);
             const poolPairData = pool.parsePoolPairData(tokenIn, tokenOut);
 
-            expect(() =>
-                pool.getLimitAmountSwap(poolPairData, SwapTypes.SwapExactIn)
-            ).to.throw('LinearPool does not support TokenToToken');
+            let amount = pool.getLimitAmountSwap(
+                poolPairData,
+                SwapTypes.SwapExactIn
+            );
 
-            expect(() =>
-                pool.getLimitAmountSwap(poolPairData, SwapTypes.SwapExactOut)
-            ).to.throw('LinearPool does not support TokenToToken');
+            expect(amount.toString()).to.eq('0');
+
+            amount = pool.getLimitAmountSwap(
+                poolPairData,
+                SwapTypes.SwapExactOut
+            );
+
+            expect(amount.toString()).to.eq('0');
         });
 
         it(`getLimitAmountSwap, SwapExactIn, TokenToBpt should return valid limit`, async () => {
@@ -571,6 +578,28 @@ describe('linear pool tests', () => {
                     smallLinear.pools
                 );
                 expect(returnAmount).to.eq('947685172351949208');
+            });
+
+            it('aDAI>staBAL3, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    aDAI.address,
+                    staBAL3.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('1', staBAL3.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('946927175843694145');
+            });
+
+            it('aDAI>WETH, SwapExactIn', async () => {
+                const returnAmount = await testFullSwap(
+                    aDAI.address,
+                    WETH.address,
+                    SwapTypes.SwapExactIn,
+                    parseFixed('1', staBAL3.decimals),
+                    smallLinear.pools
+                );
+                expect(returnAmount).to.eq('468734616507406');
             });
         });
     });


### PR DESCRIPTION
Here I changed the `getPathsUsingLinearPools` function. This should allow path creation for any token in a Linear pool (i.e. the wrapped token) so we can route trades like aDAI > WETH.
getLimitAmountSwap will return 0 amount for Token>Token instead of throwing an error.
