### PR TITLE
Fix metastable to use pricerate correctly in sp/deriv functions.

### DIFF
--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -277,6 +277,8 @@ export class MetaStablePool implements PoolBase {
         poolPairData: MetaStablePoolPairData,
         amount: OldBigNumber
     ): OldBigNumber {
+        const priceRateIn = formatFixed(poolPairData.tokenInPriceRate, 18);
+        const priceRateOut = formatFixed(poolPairData.tokenOutPriceRate, 18);
         const amountConverted = amount.times(
             formatFixed(poolPairData.tokenInPriceRate, 18)
         );
@@ -284,13 +286,15 @@ export class MetaStablePool implements PoolBase {
             amountConverted,
             poolPairData
         );
-        return result;
+        return result.div(priceRateIn).times(priceRateOut);
     }
 
     _spotPriceAfterSwapTokenInForExactTokenOut(
         poolPairData: MetaStablePoolPairData,
         amount: OldBigNumber
     ): OldBigNumber {
+        const priceRateIn = formatFixed(poolPairData.tokenInPriceRate, 18);
+        const priceRateOut = formatFixed(poolPairData.tokenOutPriceRate, 18);
         const amountConverted = amount.times(
             formatFixed(poolPairData.tokenOutPriceRate, 18)
         );
@@ -298,26 +302,32 @@ export class MetaStablePool implements PoolBase {
             amountConverted,
             poolPairData
         );
-        return result;
+        return result.div(priceRateIn).times(priceRateOut);
     }
 
     _derivativeSpotPriceAfterSwapExactTokenInForTokenOut(
         poolPairData: MetaStablePoolPairData,
         amount: OldBigNumber
     ): OldBigNumber {
+        const priceRateOut = formatFixed(poolPairData.tokenOutPriceRate, 18);
         return _derivativeSpotPriceAfterSwapExactTokenInForTokenOut(
             amount,
             poolPairData
-        );
+        ).times(priceRateOut);
     }
 
     _derivativeSpotPriceAfterSwapTokenInForExactTokenOut(
         poolPairData: MetaStablePoolPairData,
         amount: OldBigNumber
     ): OldBigNumber {
+        const priceRateIn = formatFixed(poolPairData.tokenInPriceRate, 18);
+        const priceRateOut = formatFixed(poolPairData.tokenOutPriceRate, 18);
         return _derivativeSpotPriceAfterSwapTokenInForExactTokenOut(
             amount,
             poolPairData
-        );
+        )
+            .div(priceRateIn)
+            .times(priceRateOut)
+            .times(priceRateOut);
     }
 }


### PR DESCRIPTION
SpotPrice functions & Deriv versions weren't using priceRate correctly on output. This is fixed (thanks Sergio).