### PR TITLE
Prefer the subgraph LatestPrice over Coingecko for the SwapCostCalculator

### DIFF
--- a/src/swapCost/subgraph.ts
+++ b/src/swapCost/subgraph.ts
@@ -1,0 +1,52 @@
+import fetch from 'isomorphic-fetch';
+import { SubgraphLatestTokenPrice } from '../types';
+
+export async function getTokenPriceInNativeAssetFromSubgraph(
+    tokenAddress: string,
+    wrappedNativeAssetAddress: string,
+    subgraphUrl: string
+) {
+    const latestTokenPrice = await fetchSubgraphLatestTokenPrice(
+        tokenAddress,
+        wrappedNativeAssetAddress,
+        subgraphUrl
+    );
+
+    if (!latestTokenPrice) {
+        throw Error('No latest token price available from the subgraph');
+    }
+
+    return latestTokenPrice.price;
+}
+
+async function fetchSubgraphLatestTokenPrice(
+    tokenAddress: string,
+    wrappedNativeAssetAddress: string,
+    subgraphUrl: string
+): Promise<SubgraphLatestTokenPrice | null> {
+    const query = `
+        {
+            latestPrice(id: "${tokenAddress.toLowerCase()}-${wrappedNativeAssetAddress.toLowerCase()}") {
+                price
+                pricingAsset
+                asset
+                id
+            }
+        }
+    `;
+
+    const response = await fetch(subgraphUrl, {
+        method: 'POST',
+        headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            query,
+        }),
+    });
+
+    const { data } = await response.json();
+
+    return data.latestPrice ?? null;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,13 @@ export type SubgraphToken = {
     weight: string | null;
 };
 
+export type SubgraphLatestTokenPrice = {
+    id: string;
+    asset: string;
+    pricingAsset: string;
+    price: string;
+};
+
 export interface SwapV2 {
     poolId: string;
     assetInIndex: number;

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -40,17 +40,17 @@ export class SOR {
     constructor(
         public provider: BaseProvider,
         public chainId: number,
-        poolsSource: string | null,
+        subgraphUrl: string | null,
         initialPools: SubgraphPoolBase[] = []
     ) {
         this.poolCacher = new PoolCacher(
             provider,
             chainId,
-            poolsSource,
+            subgraphUrl,
             initialPools
         );
         this.routeProposer = new RouteProposer();
-        this.swapCostCalculator = new SwapCostCalculator(chainId);
+        this.swapCostCalculator = new SwapCostCalculator(chainId, subgraphUrl);
     }
 
     getPools(): SubgraphPoolBase[] {

--- a/test/lib/constants.ts
+++ b/test/lib/constants.ts
@@ -6,3 +6,6 @@ export const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F'.toLowerCase();
 export const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'.toLowerCase();
 export const USDT = '0xdac17f958d2ee523a2206206994597c13d831ec7'.toLowerCase();
 export const GUSD = '0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd'.toLowerCase();
+
+export const SUBGRAPH_URL =
+    'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2';

--- a/test/swapCostCalculator.spec.ts
+++ b/test/swapCostCalculator.spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { BigNumber, formatFixed } from '@ethersproject/bignumber';
 import { calculateTotalSwapCost, SwapCostCalculator } from '../src/swapCost';
-import { DAI, MKR, USDC, WETH } from './lib/constants';
+import { DAI, MKR, SUBGRAPH_URL, USDC, WETH } from './lib/constants';
 
 describe('calculateTotalSwapCost', () => {
     it('should return correct total swap cost', async () => {
@@ -43,12 +43,10 @@ describe('Test SwapCostCalculator', () => {
             const swapGas = BigNumber.from('100000');
 
             const costExpected = BigNumber.from('0');
-            const cost = await new SwapCostCalculator(1).convertGasCostToToken(
-                '0x0',
-                18,
-                gasPriceWei,
-                swapGas
-            );
+            const cost = await new SwapCostCalculator(
+                1,
+                SUBGRAPH_URL
+            ).convertGasCostToToken('0x0', 18, gasPriceWei, swapGas);
 
             expect(cost).to.eql(costExpected);
         });
@@ -57,12 +55,10 @@ describe('Test SwapCostCalculator', () => {
             const gasPriceWei = BigNumber.from('30000000000');
             const swapGas = BigNumber.from('100000');
 
-            const cost = await new SwapCostCalculator(1).convertGasCostToToken(
-                DAI,
-                18,
-                gasPriceWei,
-                swapGas
-            );
+            const cost = await new SwapCostCalculator(
+                1,
+                SUBGRAPH_URL
+            ).convertGasCostToToken(DAI, 18, gasPriceWei, swapGas);
             const costEth = formatFixed(cost, 18);
             console.log(`CostOutputToken DAI: ${costEth.toString()}`);
         }).timeout(5000);
@@ -71,12 +67,10 @@ describe('Test SwapCostCalculator', () => {
             const gasPriceWei = BigNumber.from('30000000000');
             const swapGas = BigNumber.from('100000');
 
-            const cost = await new SwapCostCalculator(1).convertGasCostToToken(
-                USDC,
-                6,
-                gasPriceWei,
-                swapGas
-            );
+            const cost = await new SwapCostCalculator(
+                1,
+                SUBGRAPH_URL
+            ).convertGasCostToToken(USDC, 6, gasPriceWei, swapGas);
             const costEth = formatFixed(cost, 6);
             console.log(`CostOutputToken USDC: ${costEth.toString()}`);
         }).timeout(5000);
@@ -85,12 +79,10 @@ describe('Test SwapCostCalculator', () => {
             const gasPriceWei = BigNumber.from('30000000000');
             const swapGas = BigNumber.from('100000');
 
-            const cost = await new SwapCostCalculator(1).convertGasCostToToken(
-                MKR,
-                18,
-                gasPriceWei,
-                swapGas
-            );
+            const cost = await new SwapCostCalculator(
+                1,
+                SUBGRAPH_URL
+            ).convertGasCostToToken(MKR, 18, gasPriceWei, swapGas);
             const costEth = formatFixed(cost, 18);
             console.log(`CostOutputToken MKR: ${costEth.toString()}`);
         }).timeout(5000);
@@ -99,12 +91,10 @@ describe('Test SwapCostCalculator', () => {
             const gasPriceWei = BigNumber.from('30000000000');
             const swapGas = BigNumber.from('100000');
 
-            const cost = await new SwapCostCalculator(1).convertGasCostToToken(
-                WETH,
-                18,
-                gasPriceWei,
-                swapGas
-            );
+            const cost = await new SwapCostCalculator(
+                1,
+                SUBGRAPH_URL
+            ).convertGasCostToToken(WETH, 18, gasPriceWei, swapGas);
             const costEth = formatFixed(cost, 18);
             console.log(`CostOutputToken WETH: ${costEth.toString()}`);
         }).timeout(5000);


### PR DESCRIPTION
The issue with using Coingecko is that pricing of assets in the native token is currently not supported for non ETH chains. IE: Currently the polygon fetch fails by default.

If we leverage the `LatestPrice` from the subgraph, we're able to support any number of chains with various native assets. We also remove the third party dependency of coingecko, which notoriously does down during peak market events.

With this implementation, we are preferring to use the subgraph url if its present, but if you guys think this is a good approach, I'd suggest removing the coingecko code completely.