### PR TITLE
Added support for Linear wrappedToken<>BPT.

### DIFF
--- a/src/pools/linearPool/linearMath.ts
+++ b/src/pools/linearPool/linearMath.ts
@@ -32,7 +32,7 @@ export function _tokenInForExactTokenOut(
 
 // PairType = 'token->BPT'
 // SwapType = 'swapExactIn'
-export function _exactTokenInForBPTOut(
+export function _exactMainTokenInForBPTOut(
     amount: BigNumber,
     poolPairData: LinearPoolPairData
 ): BigNumber {
@@ -74,7 +74,7 @@ export function _exactTokenInForBPTOut(
 
 // PairType = 'token->BPT'
 // SwapType = 'swapExactOut'
-export function _tokenInForExactBPTOut(
+export function _mainTokenInForExactBPTOut(
     amount: BigNumber,
     poolPairData: LinearPoolPairData
 ): BigNumber {
@@ -116,7 +116,7 @@ export function _tokenInForExactBPTOut(
 
 // PairType = 'BPT->token'
 // SwapType = 'swapExactIn'
-export function _BPTInForExactTokenOut(
+export function _BPTInForExactMainTokenOut(
     amount: BigNumber,
     poolPairData: LinearPoolPairData
 ): BigNumber {
@@ -154,7 +154,7 @@ export function _BPTInForExactTokenOut(
 
 // PairType = 'BPT->token'
 // SwapType = 'swapExactOut'
-export function _exactBPTInForTokenOut(
+export function _exactBPTInForMainTokenOut(
     amount: BigNumber,
     poolPairData: LinearPoolPairData
 ): BigNumber {

--- a/test/linear.spec.ts
+++ b/test/linear.spec.ts
@@ -58,14 +58,14 @@ describe('linear pool tests', () => {
             const tokenIn = DAI;
             const tokenOut = bDAI;
             const poolSG = cloneDeep(singleLinear).pools[0];
-            testParsePool(poolSG, tokenIn, tokenOut, PairTypes.TokenToBpt);
+            testParsePool(poolSG, tokenIn, tokenOut, PairTypes.MainTokenToBpt);
         });
 
         it(`should correctly parse phantomBpt > token`, async () => {
             const tokenIn = bUSDC;
             const tokenOut = USDC;
             const poolSG = cloneDeep(smallLinear).pools[4];
-            testParsePool(poolSG, tokenIn, tokenOut, PairTypes.BptToToken);
+            testParsePool(poolSG, tokenIn, tokenOut, PairTypes.BptToMainToken);
         });
 
         it(`should correctly parse token > token`, async () => {
@@ -73,6 +73,30 @@ describe('linear pool tests', () => {
             const tokenOut = aDAI;
             const poolSG = cloneDeep(singleLinear).pools[0];
             testParsePool(poolSG, tokenIn, tokenOut, PairTypes.TokenToToken);
+        });
+
+        it(`should correctly parse wrappedToken > phantomBpt`, async () => {
+            const tokenIn = aDAI;
+            const tokenOut = bDAI;
+            const poolSG = cloneDeep(singleLinear).pools[0];
+            testParsePool(
+                poolSG,
+                tokenIn,
+                tokenOut,
+                PairTypes.WrappedTokenToBpt
+            );
+        });
+
+        it(`should correctly parse phantomBpt > wrappedToken`, async () => {
+            const tokenIn = bDAI;
+            const tokenOut = aDAI;
+            const poolSG = cloneDeep(singleLinear).pools[0];
+            testParsePool(
+                poolSG,
+                tokenIn,
+                tokenOut,
+                PairTypes.BptToWrappedToken
+            );
         });
     });
 
@@ -514,62 +538,110 @@ describe('linear pool tests', () => {
     });
 
     context('SOR Full Swaps', () => {
-        context('Linear Swaps', () => {
-            it('MainToken>BPT, SwapExactIn', async () => {
-                const returnAmount = await testFullSwap(
-                    USDT.address,
-                    LINEAR_AUSDT.address,
-                    SwapTypes.SwapExactIn,
-                    parseFixed('25.001542', USDT.decimals),
-                    kovanPools.pools
-                );
-                expect(returnAmount).to.eq('25004042400437802798');
+        context('Linear Pool Swaps', () => {
+            context('MainToken<>BPT', () => {
+                it('MainToken>BPT, SwapExactIn', async () => {
+                    const returnAmount = await testFullSwap(
+                        USDT.address,
+                        LINEAR_AUSDT.address,
+                        SwapTypes.SwapExactIn,
+                        parseFixed('25.001542', USDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('25004042400437802798');
+                });
+
+                it('MainToken>BPT, SwapExactOut', async () => {
+                    const returnAmount = await testFullSwap(
+                        USDT.address,
+                        LINEAR_AUSDT.address,
+                        SwapTypes.SwapExactOut,
+                        parseFixed('0.981028', LINEAR_AUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('980930');
+                });
+
+                it('BPT>MainToken, SwapExactIn', async () => {
+                    const returnAmount = await testFullSwap(
+                        LINEAR_AUSDT.address,
+                        USDT.address,
+                        SwapTypes.SwapExactIn,
+                        parseFixed('26.0872140', LINEAR_AUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('26084605');
+                });
+
+                it('BPT>MainToken, SwapExactOut', async () => {
+                    const returnAmount = await testFullSwap(
+                        LINEAR_AUSDT.address,
+                        USDT.address,
+                        SwapTypes.SwapExactOut,
+                        parseFixed('71.204293', USDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('71211414130584291114');
+                });
+
+                it('MainToken>BPT, SwapExactIn, No MainToken Initial Balance', async () => {
+                    const pools = cloneDeep(kovanPools.pools);
+                    pools[3].tokens[0].priceRate = '1.151626716668872399';
+                    const returnAmount = await testFullSwap(
+                        DAI.address,
+                        LINEAR_ADAI.address,
+                        SwapTypes.SwapExactIn,
+                        parseFixed('491.23098', DAI.decimals),
+                        pools
+                    );
+                    expect(returnAmount).to.eq('491280107230911728741');
+                });
             });
 
-            it('MainToken>BPT, SwapExactOut', async () => {
-                const returnAmount = await testFullSwap(
-                    USDT.address,
-                    LINEAR_AUSDT.address,
-                    SwapTypes.SwapExactOut,
-                    parseFixed('0.981028', LINEAR_AUSDT.decimals),
-                    kovanPools.pools
-                );
-                expect(returnAmount).to.eq('980930');
-            });
+            context('WrappedToken<>BPT', () => {
+                it('WrappedToken>BPT, SwapExactIn', async () => {
+                    const returnAmount = await testFullSwap(
+                        aUSDT.address,
+                        LINEAR_AUSDT.address,
+                        SwapTypes.SwapExactIn,
+                        parseFixed('25.001542', aUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('25018561485974317182');
+                });
 
-            it('BPT>MainToken, SwapExactIn', async () => {
-                const returnAmount = await testFullSwap(
-                    LINEAR_AUSDT.address,
-                    USDT.address,
-                    SwapTypes.SwapExactIn,
-                    parseFixed('26.0872140', LINEAR_AUSDT.decimals),
-                    kovanPools.pools
-                );
-                expect(returnAmount).to.eq('26084605');
-            });
+                it('WrappedToken>BPT, SwapExactOut', async () => {
+                    const returnAmount = await testFullSwap(
+                        aUSDT.address,
+                        LINEAR_AUSDT.address,
+                        SwapTypes.SwapExactOut,
+                        parseFixed('0.981028', LINEAR_AUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('980360');
+                });
 
-            it('BPT>MainToken, SwapExactOut', async () => {
-                const returnAmount = await testFullSwap(
-                    LINEAR_AUSDT.address,
-                    USDT.address,
-                    SwapTypes.SwapExactOut,
-                    parseFixed('71.204293', USDT.decimals),
-                    kovanPools.pools
-                );
-                expect(returnAmount).to.eq('71211414130584291114');
-            });
+                it('BPT>WrappedToken, SwapExactIn', async () => {
+                    const returnAmount = await testFullSwap(
+                        LINEAR_AUSDT.address,
+                        aUSDT.address,
+                        SwapTypes.SwapExactIn,
+                        parseFixed('26.0872140', LINEAR_AUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('26069467');
+                });
 
-            it('MainToken>BPT, SwapExactIn, No MainToken Initial Balance', async () => {
-                const pools = cloneDeep(kovanPools.pools);
-                pools[3].tokens[0].priceRate = '1.151626716668872399';
-                const returnAmount = await testFullSwap(
-                    DAI.address,
-                    LINEAR_ADAI.address,
-                    SwapTypes.SwapExactIn,
-                    parseFixed('491.23098', DAI.decimals),
-                    pools
-                );
-                expect(returnAmount).to.eq('491280107230911728741');
+                it('BPT>MainToken, SwapExactOut', async () => {
+                    const returnAmount = await testFullSwap(
+                        LINEAR_AUSDT.address,
+                        aUSDT.address,
+                        SwapTypes.SwapExactOut,
+                        parseFixed('71.204293', aUSDT.decimals),
+                        kovanPools.pools
+                    );
+                    expect(returnAmount).to.eq('71252764000000000000');
+                });
             });
         });
 

--- a/test/linearMath.spec.ts
+++ b/test/linearMath.spec.ts
@@ -10,7 +10,7 @@ import { LinearPoolPairData } from '../src/pools/linearPool/linearPool';
 describe('linear math tests', () => {
     let poolPairData; //  = makeLinearPoolPairData(0, 0);
     context('swap outcomes', () => {
-        it('_exactTokenInForBPTOut', () => {
+        it('_exactMainTokenInForBPTOut', () => {
             poolPairData = makeLinearPoolPairData(
                 parseFixed('10000', 18), // balanceIn
                 parseFixed('10000', 18), // balanceOut
@@ -19,7 +19,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._exactTokenInForBPTOut,
+                linearMath._exactMainTokenInForBPTOut,
                 poolPairData,
                 100,
                 98.307150862,
@@ -33,7 +33,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._exactTokenInForBPTOut,
+                linearMath._exactMainTokenInForBPTOut,
                 poolPairData,
                 1300,
                 12615.3259478,
@@ -41,7 +41,7 @@ describe('linear math tests', () => {
             );
         });
 
-        it('_tokenInForExactBPTOut', () => {
+        it('_mainTokenInForExactBPTOut', () => {
             poolPairData = makeLinearPoolPairData(
                 parseFixed('900', 18), // balanceIn
                 parseFixed('10000', 18), // balanceOut
@@ -50,14 +50,14 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._tokenInForExactBPTOut,
+                linearMath._mainTokenInForExactBPTOut,
                 poolPairData,
                 100,
                 10.078,
                 0.000000001
             );
             checkOutcome(
-                linearMath._tokenInForExactBPTOut,
+                linearMath._mainTokenInForExactBPTOut,
                 poolPairData,
                 5000,
                 512.5510204,
@@ -65,7 +65,7 @@ describe('linear math tests', () => {
             );
         });
 
-        it('_BPTInForExactTokenOut', () => {
+        it('_BPTInForExactMainTokenOut', () => {
             poolPairData = makeLinearPoolPairData(
                 parseFixed('10000', 18), // balanceIn
                 parseFixed('900', 18), // balanceOut
@@ -74,7 +74,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 poolPairData,
                 200,
                 1984.520738,
@@ -88,14 +88,14 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 poolPairData,
                 1600,
                 6074.64002,
                 0.000001
             );
             checkOutcome(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 poolPairData,
                 800,
                 3014.744405,
@@ -103,7 +103,7 @@ describe('linear math tests', () => {
             );
         });
 
-        it('_exactBPTInForTokenOut', () => {
+        it('_exactBPTInForMainTokenOut', () => {
             poolPairData = makeLinearPoolPairData(
                 parseFixed('10000', 18), // balanceIn
                 parseFixed('2500', 18), // balanceOut
@@ -112,14 +112,14 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkOutcome(
-                linearMath._exactBPTInForTokenOut,
+                linearMath._exactBPTInForMainTokenOut,
                 poolPairData,
                 200,
                 53.444,
                 0.000001
             );
             checkOutcome(
-                linearMath._exactBPTInForTokenOut,
+                linearMath._exactBPTInForMainTokenOut,
                 poolPairData,
                 5000,
                 1320.098039,
@@ -138,7 +138,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkDerivative(
-                linearMath._exactTokenInForBPTOut,
+                linearMath._exactMainTokenInForBPTOut,
                 linearMath._spotPriceAfterSwapExactTokenInForBPTOut,
                 poolPairData,
                 200,
@@ -147,7 +147,7 @@ describe('linear math tests', () => {
                 true
             );
             checkDerivative(
-                linearMath._exactTokenInForBPTOut,
+                linearMath._exactMainTokenInForBPTOut,
                 linearMath._spotPriceAfterSwapExactTokenInForBPTOut,
                 poolPairData,
                 1500,
@@ -159,7 +159,7 @@ describe('linear math tests', () => {
 
         it('_spotPriceAfterSwapTokenInForExactBPTOut', () => {
             checkDerivative(
-                linearMath._tokenInForExactBPTOut,
+                linearMath._mainTokenInForExactBPTOut,
                 linearMath._spotPriceAfterSwapTokenInForExactBPTOut,
                 poolPairData,
                 500,
@@ -168,7 +168,7 @@ describe('linear math tests', () => {
                 false
             );
             checkDerivative(
-                linearMath._tokenInForExactBPTOut,
+                linearMath._mainTokenInForExactBPTOut,
                 linearMath._spotPriceAfterSwapTokenInForExactBPTOut,
                 poolPairData,
                 40000,
@@ -187,7 +187,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkDerivative(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 linearMath._spotPriceAfterSwapBPTInForExactTokenOut,
                 poolPairData,
                 200,
@@ -196,7 +196,7 @@ describe('linear math tests', () => {
                 false
             );
             checkDerivative(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 linearMath._spotPriceAfterSwapBPTInForExactTokenOut,
                 poolPairData,
                 1600,
@@ -205,7 +205,7 @@ describe('linear math tests', () => {
                 false
             );
             checkDerivative(
-                linearMath._BPTInForExactTokenOut,
+                linearMath._BPTInForExactMainTokenOut,
                 linearMath._spotPriceAfterSwapBPTInForExactTokenOut,
                 poolPairData,
                 3000,
@@ -224,7 +224,7 @@ describe('linear math tests', () => {
                 parseFixed('10000', 0) // virtualBptSupply
             );
             checkDerivative(
-                linearMath._exactBPTInForTokenOut,
+                linearMath._exactBPTInForMainTokenOut,
                 linearMath._spotPriceAfterSwapExactBPTInForTokenOut,
                 poolPairData,
                 200,
@@ -233,7 +233,7 @@ describe('linear math tests', () => {
                 true
             );
             checkDerivative(
-                linearMath._exactBPTInForTokenOut,
+                linearMath._exactBPTInForMainTokenOut,
                 linearMath._spotPriceAfterSwapExactBPTInForTokenOut,
                 poolPairData,
                 5000,
@@ -242,7 +242,7 @@ describe('linear math tests', () => {
                 true
             );
             checkDerivative(
-                linearMath._exactBPTInForTokenOut,
+                linearMath._exactBPTInForMainTokenOut,
                 linearMath._spotPriceAfterSwapExactBPTInForTokenOut,
                 poolPairData,
                 8000,

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -37,7 +37,7 @@ export const SUBGRAPH_URLS = {
     [Network.GOERLI]:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2',
     [Network.KOVAN]:
-        'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-kovan-v2', // 'https://api.thegraph.com/subgraphs/name/destiner/balancer-kovan-v2',
+        'https://api.thegraph.com/subgraphs/name/destiner/balancer-kovan-v2',
     [Network.POLYGON]:
         'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-polygon-v2',
     [Network.ARBITRUM]: `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-arbitrum-v2`,
@@ -143,6 +143,11 @@ export const ADDRESSES = {
             address: '0xe8191aacfcdb32260cda25830dc6c9342142f310',
             decimals: 6,
             symbol: 'aUSDT',
+        },
+        aUSDC: {
+            address: '0x0fbddc06a4720408a2f5eb78e62bc31ac6e2a3c4',
+            decimals: 6,
+            symbol: 'aUSDC',
         },
         bUSDT: {
             address: '0x6a8c3239695613c0710dc971310b36f9b81e115e',
@@ -588,11 +593,11 @@ async function simpleSwap() {
     const poolsSource = SUBGRAPH_URLS[networkId];
     // const poolsSource = require('../testData/testPools/gusdBug.json');
     // Update pools list with most recent onchain balances
-    const queryOnChain = true;
-    const tokenIn = ADDRESSES[networkId].BAL;
-    const tokenOut = ADDRESSES[networkId].WETH;
+    const queryOnChain = false;
+    const tokenIn = ADDRESSES[networkId].STABAL3;
+    const tokenOut = ADDRESSES[networkId].aUSDC;
     const swapType = SwapTypes.SwapExactIn;
-    const swapAmount = parseFixed('0.001', 18);
+    const swapAmount = parseFixed('1000', 18);
     const executeTrade = true;
 
     const provider = new JsonRpcProvider(PROVIDER_URLS[networkId]);


### PR DESCRIPTION
Adding some basic support for Linear pool wrappedToken swaps with BPT which is needed for larger exits using relayer.
Because we don’t have the TS maths functions:
* SDK maths is used for the final amounts which should make sure this is accurate.
* For LinearPool SP functions it uses the main token variants. Although this won't be accurate it shouldn't be an issue because there is limtied paths available.