### PR TITLE
Fix swapExample script

### DIFF
--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -24,7 +24,7 @@ import {
     _derivativeSpotPriceAfterSwapExactTokenInForTokenOut,
     _derivativeSpotPriceAfterSwapTokenInForExactTokenOut,
 } from './metaStableMath';
-import { StablePoolPairData } from 'pools/stablePool/stablePool';
+import { StablePoolPairData } from '../stablePool/stablePool';
 
 type MetaStablePoolToken = Pick<
     SubgraphToken,

--- a/test/testScripts/README.md
+++ b/test/testScripts/README.md
@@ -4,6 +4,6 @@ Examples and some non-deterministic testing helpers.
 
 ### swapExample.ts
 
-Run: `$ ts-node ./test/testScripts/swapExample.ts`
+Run: `$ ts-node --compiler-options '{"module": "commonjs"}' ./test/testScripts/swapExample.ts`
 
 Example showing how to use SOR and Vault to execute swaps. Can configure different swap types and pool sources as well as use Mainnet or Kovan.


### PR DESCRIPTION
The swapExample.ts script wasn't working out of the box. I got it working with these two changes.

- Update README to include that you have to run this script as a module for the import's to work.
- Fix import in metaStablePool.