### PR TITLE
SOR support for wrapped rebasing tokens using the generic unbutton wrapper

### DIFF
--- a/src/wrapInfo.ts
+++ b/src/wrapInfo.ts
@@ -1,11 +1,10 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Provider } from '@ethersproject/providers';
 import { AddressZero, WeiPerEther as ONE } from '@ethersproject/constants';
-
 import { Lido, getStEthRate } from './pools/lido';
 import {
     TokensToUnbuttonWrapperMap,
-    getUnderlyingToWrapper,
+    getWrapperRate as getUnbuttonWrapperRate,
 } from './wrappers/unbutton';
 import { WETHADDR } from './constants';
 import { SwapTypes, SwapInfo } from './types';
@@ -100,12 +99,7 @@ export async function getWrappedInfo(
     if (tokensToUBWrapperMap[tokenIn]) {
         tokenInForSwaps = tokensToUBWrapperMap[tokenIn];
         tokenInWrapType = WrapTypes.Unbutton;
-        tokenInRate = await getUnderlyingToWrapper(
-            provider,
-            chainId,
-            tokenInForSwaps,
-            ONE
-        );
+        tokenInRate = await getUnbuttonWrapperRate(provider, tokenInForSwaps);
         if (swapType === SwapTypes.SwapExactIn)
             swapAmountForSwaps = swapAmount.mul(tokenInRate).div(ONE);
     }
@@ -114,12 +108,7 @@ export async function getWrappedInfo(
     if (tokensToUBWrapperMap[tokenOut]) {
         tokenOutForSwaps = tokensToUBWrapperMap[tokenOut];
         tokenOutWrapType = WrapTypes.Unbutton;
-        tokenOutRate = await getUnderlyingToWrapper(
-            provider,
-            chainId,
-            tokenOutForSwaps,
-            ONE
-        );
+        tokenOutRate = await getUnbuttonWrapperRate(provider, tokenOutForSwaps);
         if (swapType === SwapTypes.SwapExactOut)
             swapAmountForSwaps = swapAmount.mul(tokenOutRate).div(ONE);
     }

--- a/src/wrapInfo.ts
+++ b/src/wrapInfo.ts
@@ -3,6 +3,10 @@ import { Provider } from '@ethersproject/providers';
 import { AddressZero, WeiPerEther as ONE } from '@ethersproject/constants';
 
 import { Lido, getStEthRate } from './pools/lido';
+import {
+    TokensToUnbuttonWrapperMap,
+    getUnderlyingToWrapper,
+} from './wrappers/unbutton';
 import { WETHADDR } from './constants';
 import { SwapTypes, SwapInfo } from './types';
 import { isSameAddress } from './utils';
@@ -23,8 +27,9 @@ export interface TokenInfo {
 
 export enum WrapTypes {
     None,
-    ETH,
-    stETH,
+    ETH, // ETH -> WETH
+    stETH, // stETH -> wSTETH
+    Unbutton, // [rebasing Token] -> ubToken
 }
 
 export async function getWrappedInfo(
@@ -40,7 +45,6 @@ export async function getWrappedInfo(
     tokenOut = tokenOut.toLowerCase();
 
     let swapAmountForSwaps = swapAmount;
-
     let tokenInForSwaps = tokenIn;
     let tokenInWrapType = WrapTypes.None;
     let tokenOutForSwaps = tokenOut;
@@ -48,15 +52,23 @@ export async function getWrappedInfo(
     let tokenInRate = ONE;
     let tokenOutRate = ONE;
 
+    //--------------------------------------------------------------------------
+    // ETH/WETH
+
     // Handle ETH wrapping
     if (tokenIn === AddressZero) {
         tokenInForSwaps = WETHADDR[chainId].toLowerCase();
         tokenInWrapType = WrapTypes.ETH;
     }
+
+    // Handle WETH unwrapping
     if (tokenOut === AddressZero) {
         tokenOutForSwaps = WETHADDR[chainId].toLowerCase();
         tokenOutWrapType = WrapTypes.ETH;
     }
+
+    //--------------------------------------------------------------------------
+    // stETH/wstETH
 
     // Handle stETH wrapping
     if (tokenIn === Lido.stETH[chainId]) {
@@ -67,6 +79,8 @@ export async function getWrappedInfo(
         if (swapType === SwapTypes.SwapExactIn)
             swapAmountForSwaps = swapAmount.mul(rate).div(ONE);
     }
+
+    // Handle wstETH unwrapping
     if (tokenOut === Lido.stETH[chainId]) {
         tokenOutForSwaps = Lido.wstETH[chainId];
         tokenOutWrapType = WrapTypes.stETH;
@@ -75,6 +89,42 @@ export async function getWrappedInfo(
         if (swapType === SwapTypes.SwapExactOut)
             swapAmountForSwaps = swapAmount.mul(rate).div(ONE);
     }
+
+    //--------------------------------------------------------------------------
+    // ubTokens
+
+    // Gets a list of all the tokens and their unbutton wrappers
+    const tokensToUBWrapperMap = TokensToUnbuttonWrapperMap[chainId] || {};
+
+    // Handle token unbutton wrapping
+    if (tokensToUBWrapperMap[tokenIn]) {
+        tokenInForSwaps = tokensToUBWrapperMap[tokenIn];
+        tokenInWrapType = WrapTypes.Unbutton;
+        tokenInRate = await getUnderlyingToWrapper(
+            provider,
+            chainId,
+            tokenInForSwaps,
+            ONE
+        );
+        if (swapType === SwapTypes.SwapExactIn)
+            swapAmountForSwaps = swapAmount.mul(tokenInRate).div(ONE);
+    }
+
+    // Handle unbutton token unwrapping
+    if (tokensToUBWrapperMap[tokenOut]) {
+        tokenOutForSwaps = tokensToUBWrapperMap[tokenOut];
+        tokenOutWrapType = WrapTypes.Unbutton;
+        tokenOutRate = await getUnderlyingToWrapper(
+            provider,
+            chainId,
+            tokenOutForSwaps,
+            ONE
+        );
+        if (swapType === SwapTypes.SwapExactOut)
+            swapAmountForSwaps = swapAmount.mul(tokenOutRate).div(ONE);
+    }
+
+    //--------------------------------------------------------------------------
 
     return {
         swapAmountOriginal: swapAmount,
@@ -105,37 +155,55 @@ export function setWrappedInfo(
     swapInfo.tokenIn = wrappedInfo.tokenIn.addressOriginal;
     swapInfo.tokenOut = wrappedInfo.tokenOut.addressOriginal;
 
+    swapInfo.swapAmountForSwaps = swapInfo.swapAmount;
+    swapInfo.returnAmountFromSwaps = swapInfo.returnAmount;
+
+    // No wrapping required
+    if (
+        wrappedInfo.tokenIn.wrapType === WrapTypes.None &&
+        wrappedInfo.tokenOut.wrapType === WrapTypes.None
+    ) {
+        return swapInfo;
+    }
+
+    //--------------------------------------------------------------------------
+    // Wrappers which are 1:1 (ETH/WETH), ie UnscaledWrappers
+    // Replace weth with ZERO/ETH in assets for Vault to handle ETH directly
     if (
         wrappedInfo.tokenIn.wrapType === WrapTypes.ETH ||
         wrappedInfo.tokenOut.wrapType === WrapTypes.ETH
     ) {
-        // replace weth with ZERO/ETH in assets for Vault to handle ETH directly
         swapInfo.tokenAddresses = swapInfo.tokenAddresses.map((addr) =>
             isSameAddress(addr, WETHADDR[chainId]) ? AddressZero : addr
         );
     }
 
-    // Handle stETH swap amount scaling
+    //--------------------------------------------------------------------------
+    // Wrappers which are NOT 1:1 (stETH/wstETH, AMPL/WAMPL, all ubTokens etc)
+    // ie ScaledWrappers
+
+    const isScaledWrapper = (wrapType) =>
+        wrapType === WrapTypes.stETH || wrapType === WrapTypes.Unbutton;
+
+    // Scaling required for wrappers which don't scale 1:1 with the underlying token
+    // swap amount and return amounts are scaled if swap type is SwapExact
+
+    // Handle swap amount scaling
     if (
-        (wrappedInfo.tokenIn.wrapType === WrapTypes.stETH &&
+        (isScaledWrapper(wrappedInfo.tokenIn.wrapType) &&
             swapType === SwapTypes.SwapExactIn) ||
-        (wrappedInfo.tokenOut.wrapType === WrapTypes.stETH &&
+        (isScaledWrapper(wrappedInfo.tokenOut.wrapType) &&
             swapType === SwapTypes.SwapExactOut)
     ) {
-        swapInfo.swapAmountForSwaps = wrappedInfo.swapAmountForSwaps;
         swapInfo.swapAmount = wrappedInfo.swapAmountOriginal;
-    } else {
-        // Should be same when standard tokens and swapAmount should already be scaled
-        swapInfo.swapAmountForSwaps = swapInfo.swapAmount;
+        swapInfo.swapAmountForSwaps = wrappedInfo.swapAmountForSwaps;
     }
 
-    // Return amount from swaps will only be different if token has an exchangeRate
-    swapInfo.returnAmountFromSwaps = swapInfo.returnAmount;
-
-    // SwapExactIn, stETH out, returnAmount is stETH amount out, returnAmountForSwaps is wstETH amount out
+    // Handle return amount scaling
+    // SwapExactIn, unwrapped out, returnAmount is unwrapped amount out, returnAmountForSwaps is wrapped amount out
     if (
         swapType === SwapTypes.SwapExactIn &&
-        wrappedInfo.tokenOut.wrapType === WrapTypes.stETH
+        isScaledWrapper(wrappedInfo.tokenOut.wrapType)
     ) {
         swapInfo.returnAmount = swapInfo.returnAmount
             .mul(ONE)
@@ -147,10 +215,10 @@ export function setWrappedInfo(
                 .div(wrappedInfo.tokenOut.rate);
     }
 
-    // SwapExactOut, stETH in, returnAmount us stETH amount in, returnAmountForSwaps is wstETH amount in
+    // SwapExactOut, unwrapped in, returnAmount us unwrapped amount in, returnAmountForSwaps is wrapped amount in
     if (
         swapType === SwapTypes.SwapExactOut &&
-        wrappedInfo.tokenIn.wrapType === WrapTypes.stETH
+        isScaledWrapper(wrappedInfo.tokenIn.wrapType)
     ) {
         swapInfo.returnAmount = swapInfo.returnAmount
             .mul(ONE)
@@ -161,5 +229,6 @@ export function setWrappedInfo(
                 .mul(ONE)
                 .div(wrappedInfo.tokenIn.rate);
     }
+
     return swapInfo;
 }

--- a/src/wrappers/unbutton.ts
+++ b/src/wrappers/unbutton.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from '@ethersproject/bignumber';
 import { Provider } from '@ethersproject/providers';
 import { Contract } from '@ethersproject/contracts';
+import { WeiPerEther as ONE } from '@ethersproject/constants';
 
 // The unbutton ERC-20 wrapper is a generic wrapper which wraps any rebasing token
 // into a fixed balance version.
@@ -21,11 +22,11 @@ export const TokensToUnbuttonWrapperMap = {
     },
 };
 
-export async function getUnderlyingToWrapper(
+// Returns the current wrapper exchange rate,
+// ie) number of wrapper tokens for 1e18 (ONE) underlying token
+export async function getWrapperRate(
     provider: Provider,
-    chainId: number,
-    wrapperAddress: string,
-    amount: BigNumber
+    wrapperAddress: string
 ): Promise<BigNumber> {
     const ubWrapper = new Contract(
         wrapperAddress,
@@ -34,5 +35,5 @@ export async function getUnderlyingToWrapper(
         ],
         provider
     );
-    return ubWrapper.underlyingToWrapper(amount);
+    return ubWrapper.underlyingToWrapper(ONE);
 }

--- a/src/wrappers/unbutton.ts
+++ b/src/wrappers/unbutton.ts
@@ -1,0 +1,38 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { Provider } from '@ethersproject/providers';
+import { Contract } from '@ethersproject/contracts';
+
+// The unbutton ERC-20 wrapper is a generic wrapper which wraps any rebasing token
+// into a fixed balance version.
+// https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/UnbuttonToken.sol#L18
+
+export const TokensToUnbuttonWrapperMap = {
+    Networks: [1],
+    1: {
+        // underlying => wrapper
+
+        // AMPL => WAMPL
+        '0xd46ba6d942050d489dbd938a2c909a5d5039a161':
+            '0xedb171c18ce90b633db442f2a6f72874093b49ef',
+
+        // aAMPL -> ubAAMPL
+        '0x1e6bb68acec8fefbd87d192be09bb274170a0548':
+            '0xF03387d8d0FF326ab586A58E0ab4121d106147DF',
+    },
+};
+
+export async function getUnderlyingToWrapper(
+    provider: Provider,
+    chainId: number,
+    wrapperAddress: string,
+    amount: BigNumber
+): Promise<BigNumber> {
+    const ubWrapper = new Contract(
+        wrapperAddress,
+        [
+            'function underlyingToWrapper(uint256 amount) external view returns (uint256)',
+        ],
+        provider
+    );
+    return ubWrapper.underlyingToWrapper(amount);
+}


### PR DESCRIPTION
The [unbutton wrapper](https://github.com/buttonwood-protocol/button-wrappers/blob/main/contracts/UnbuttonToken.sol#L18) is a ERC-20 wrapper which  wraps any generic rebasing ERC-20 token into a non-rebasing, fixed balance version.

For example:
Wrapped Ampleforth (WAMPL) is a non-rebasing version of the AMPL ERC-20. LPs create BalV2 pools using WAMPL. When traders want to trade AMPL, the sor calculates the exchange rate between AMPL/WAMPL and routes trades through the WAMPL pools. (similar to the existing stETH/wstETH implementation). 

The current will allow the SOR to handle any rebasing tokens as long as they use the the generic "unbutton" wrapper without any custom integration.