### PR TITLE
John/1 add erc4626 pool

### DIFF
--- a/src/pools/index.ts
+++ b/src/pools/index.ts
@@ -52,7 +52,10 @@ export function parseNewPool(
         } else if (pool.poolType === 'Element') {
             newPool = ElementPool.fromPool(pool);
             newPool.setCurrentBlockTimestamp(currentBlockTimestamp);
-        } else if (pool.poolType.toString().includes('Linear'))
+        } else if (
+            pool.poolType.toString().includes('Linear') ||
+            pool.poolType === 'ERC4626Linear'
+        )
             newPool = LinearPool.fromPool(pool);
         else if (pool.poolType === 'StablePhantom')
             newPool = PhantomStablePool.fromPool(pool);

--- a/src/pools/index.ts
+++ b/src/pools/index.ts
@@ -52,10 +52,7 @@ export function parseNewPool(
         } else if (pool.poolType === 'Element') {
             newPool = ElementPool.fromPool(pool);
             newPool.setCurrentBlockTimestamp(currentBlockTimestamp);
-        } else if (
-            pool.poolType.toString().includes('Linear') ||
-            pool.poolType === 'ERC4626Linear'
-        )
+        } else if (pool.poolType.toString().includes('Linear'))
             newPool = LinearPool.fromPool(pool);
         else if (pool.poolType === 'StablePhantom')
             newPool = PhantomStablePool.fromPool(pool);

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export enum PoolFilter {
     Element = 'Element',
     AaveLinear = 'AaveLinear',
     StablePhantom = 'StablePhantom',
+    ERC4626Linear = 'ERC4626Linear',
 }
 
 export interface PoolBase {

--- a/test/lib/onchainData.ts
+++ b/test/lib/onchainData.ts
@@ -85,10 +85,7 @@ export async function getOnChainBalances(
             );
         } else if (pool.poolType === 'Element') {
             multiPool.call(`${pool.id}.swapFee`, pool.address, 'percentFee');
-        } else if (
-            pool.poolType === 'AaveLinear' ||
-            pool.poolType === 'ERC4626Linear'
-        ) {
+        } else if (pool.poolType.toString().includes('Linear')) {
             multiPool.call(
                 `${pool.id}.swapFee`,
                 pool.address,
@@ -161,10 +158,7 @@ export async function getOnChainBalances(
                 }
             }
 
-            if (
-                subgraphPools[index].poolType === 'AaveLinear' ||
-                subgraphPools[index].poolType === 'ERC4626Linear'
-            ) {
+            if (subgraphPools[index].poolType.includes('Linear')) {
                 if (!onchainData.targets) {
                     console.error(`Linear Pool Missing Targets: ${poolId}`);
                     return;

--- a/test/lib/onchainData.ts
+++ b/test/lib/onchainData.ts
@@ -85,7 +85,10 @@ export async function getOnChainBalances(
             );
         } else if (pool.poolType === 'Element') {
             multiPool.call(`${pool.id}.swapFee`, pool.address, 'percentFee');
-        } else if (pool.poolType === 'AaveLinear') {
+        } else if (
+            pool.poolType === 'AaveLinear' ||
+            pool.poolType === 'ERC4626Linear'
+        ) {
             multiPool.call(
                 `${pool.id}.swapFee`,
                 pool.address,
@@ -158,7 +161,10 @@ export async function getOnChainBalances(
                 }
             }
 
-            if (subgraphPools[index].poolType === 'AaveLinear') {
+            if (
+                subgraphPools[index].poolType === 'AaveLinear' ||
+                subgraphPools[index].poolType === 'ERC4626Linear'
+            ) {
                 if (!onchainData.targets) {
                     console.error(`Linear Pool Missing Targets: ${poolId}`);
                     return;

--- a/test/lib/subgraphPoolDataService.ts
+++ b/test/lib/subgraphPoolDataService.ts
@@ -77,7 +77,7 @@ export const Query: { [chainId: number]: string } = {
     4: queryWithLinear,
     5: queryWithLinear,
     42: queryWithLinear,
-    137: queryWithOutLinear,
+    137: queryWithLinear,
     42161: queryWithLinear,
 };
 

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -288,6 +288,21 @@ export const ADDRESSES = {
             decimals: 18,
             symbol: 'DAI',
         },
+        STETH: {
+            address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+            decimals: 18,
+            symbol: 'STETH',
+        },
+        stUSD_PLUS: {
+            address: '0x5a5c6aa6164750b530b8f7658b827163b3549a4d',
+            decimals: 6,
+            symbol: 'stUSD+',
+        },
+        bstUSD_PLUS: {
+            address: '0x1aafc31091d93c3ff003cff5d2d8f7ba2e728425',
+            decimals: 18,
+            symbol: 'bstUSD+',
+        },
     },
     [Network.ARBITRUM]: {
         WETH: {
@@ -674,13 +689,13 @@ async function makeRelayerTrade(
 }
 
 export async function simpleSwap() {
-    const networkId = Network.MAINNET;
+    const networkId = Network.POLYGON;
     // Pools source can be Subgraph URL or pools data set passed directly
     // Update pools list with most recent onchain balances
-    const tokenIn = ADDRESSES[networkId].bbausdc;
-    const tokenOut = ADDRESSES[networkId].waUSDC;
-    const swapType = SwapTypes.SwapExactOut;
-    const swapAmount = parseFixed('10', 6);
+    const tokenIn = ADDRESSES[networkId].bstUSD_PLUS;
+    const tokenOut = ADDRESSES[networkId].BAL;
+    const swapType = SwapTypes.SwapExactIn;
+    const swapAmount = parseFixed('0.1', 18);
     const executeTrade = true;
 
     const provider = new JsonRpcProvider(PROVIDER_URLS[networkId]);


### PR DESCRIPTION
Adds support for new ERC4626 pool type.
* Updated Polygon Subgraph query to include Linear pool information.
* Changed onChain to use same `.includes('Linear')` syntax as parseNewPool
* !Based off assumption that this pool has same maths as Linear pools!