### PR TITLE
Fix path to stablePool include in metaStablePool

### DIFF
--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -20,7 +20,7 @@ import {
     _calcOutGivenIn,
     _calcInGivenOut,
 } from '../stablePool/stableMathBigInt';
-import { StablePoolPairData } from 'pools/stablePool/stablePool';
+import { StablePoolPairData } from '../stablePool/stablePool';
 
 type MetaStablePoolToken = Pick<
     SubgraphToken,


### PR DESCRIPTION
When building the Pools API with the latest version of SOR it was throwing an error:

```
node_modules/@balancer-labs/sor/dist/index.d.ts:6:60 - error TS2307: Cannot find module 'pools/stablePool/stablePool' or its corresponding type declarations.

6 import { StablePoolPairData as StablePoolPairData$1 } from 'pools/stablePool/stablePool';
                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Found 1 error in node_modules/@balancer-labs/sor/dist/index.d.ts:6
```

After fixing the path in SOR, making it relative instead of absolute, building, and copying the output files into pools API it now works correctly. I'm not sure how this is building correctly for others as this change went in months ago. 

