### PR TITLE
Fix token balance updates in EVMgetOutputAmountSwap

### DIFF
--- a/src/router/helpersClass.ts
+++ b/src/router/helpersClass.ts
@@ -356,12 +356,17 @@ export function EVMgetOutputAmountSwap(
             throw Error('Unsupported swap');
         }
     }
+
+    const amountIn = swapType === SwapTypes.SwapExactIn ? amount : returnAmount;
+    const amountOut =
+        swapType === SwapTypes.SwapExactIn ? returnAmount : amount;
+
     // Update balances of tokenIn and tokenOut
     pool.updateTokenBalanceForPool(
         tokenIn,
         balanceIn.add(
             parseFixed(
-                returnAmount.dp(poolPairData.decimalsIn).toString(),
+                amountIn.dp(poolPairData.decimalsIn).toString(),
                 poolPairData.decimalsIn
             )
         )
@@ -370,7 +375,7 @@ export function EVMgetOutputAmountSwap(
         tokenOut,
         balanceOut.sub(
             parseFixed(
-                amount.dp(poolPairData.decimalsOut).toString(),
+                amountOut.dp(poolPairData.decimalsOut).toString(),
                 poolPairData.decimalsOut
             )
         )

--- a/src/router/helpersClass.ts
+++ b/src/router/helpersClass.ts
@@ -303,6 +303,12 @@ export function EVMgetOutputAmountSwap(
     swapType: SwapTypes,
     amount: OldBigNumber
 ): OldBigNumber {
+    //we recalculate the pool pair data since balance updates are not reflected immediately in cached poolPairData
+    poolPairData = pool.parsePoolPairData(
+        poolPairData.tokenIn,
+        poolPairData.tokenOut
+    );
+
     const { balanceIn, balanceOut, tokenIn, tokenOut } = poolPairData;
 
     let returnAmount: OldBigNumber;

--- a/test/updateTokenBalanceTest.spec.ts
+++ b/test/updateTokenBalanceTest.spec.ts
@@ -1,0 +1,35 @@
+// TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/linear.spec.ts
+import { formatSwaps } from '../src/router/sorClass';
+import { createPath } from '../src/routeProposal/filtering';
+import { assert } from 'chai';
+import cloneDeep from 'lodash.clonedeep';
+import { SwapTypes } from '../src';
+import { parseToPoolsDict } from '../src/routeProposal/filtering';
+import boostedPools from './testData/boostedPools/multipleBoosted.json';
+import { WETH, BAL } from './lib/constants';
+import { bnum } from '../src/utils/bignumber';
+
+describe('fails if token balances are not updated after a swap', () => {
+    const poolsAll = parseToPoolsDict(cloneDeep(boostedPools.pools), 0);
+    const pool = poolsAll['weightedBalWeth'];
+    const path = createPath([WETH.address, BAL.address], [pool]);
+    it('updateTokenBalance - WETH-BAL', () => {
+        const [, returnDouble] = formatSwaps(
+            [path, path],
+            SwapTypes.SwapExactIn,
+            bnum(100),
+            [bnum(50), bnum(50)]
+        );
+        const [, returnSingle] = formatSwaps(
+            [path],
+            SwapTypes.SwapExactIn,
+            bnum(50),
+            [bnum(50)]
+        );
+        const difference = returnDouble.minus(returnSingle.times(2));
+        assert.isNotTrue(
+            difference.toNumber() == 0,
+            'balances were not updated'
+        );
+    });
+});


### PR DESCRIPTION
Depending on the swap type, the amount and returnAmount have different meanings that is not being accounted for on the updateTokenBalanceForPool calls. I think this has never been discovered as an issue on your guys' side because it's rare that the same pool is used more than once in a path.
