### PR TITLE
Update Gyro pools limitAmountSwap

### DIFF
--- a/src/pools/gyro2Pool/constants.ts
+++ b/src/pools/gyro2Pool/constants.ts
@@ -1,9 +1,6 @@
-import { BigNumber, parseFixed } from '@ethersproject/bignumber';
+import { BigNumber } from '@ethersproject/bignumber';
 
 // Swap limits: amounts swapped may not be larger than this percentage of total balance.
-
-export const _MAX_IN_RATIO: BigNumber = parseFixed('0.3', 18);
-export const _MAX_OUT_RATIO: BigNumber = parseFixed('0.3', 18);
 
 export const SQRT_1E_NEG_1 = BigNumber.from('316227766016837933');
 export const SQRT_1E_NEG_3 = BigNumber.from('31622776601683793');
@@ -14,3 +11,6 @@ export const SQRT_1E_NEG_11 = BigNumber.from('3162277660168');
 export const SQRT_1E_NEG_13 = BigNumber.from('316227766016');
 export const SQRT_1E_NEG_15 = BigNumber.from('31622776601');
 export const SQRT_1E_NEG_17 = BigNumber.from('3162277660');
+
+// Swap Limit factor
+export const SWAP_LIMIT_FACTOR = BigNumber.from('999999000000000000');

--- a/src/pools/gyro3Pool/constants.ts
+++ b/src/pools/gyro3Pool/constants.ts
@@ -1,9 +1,4 @@
-import { BigNumber, parseFixed } from '@ethersproject/bignumber';
-
-// Swap limits: amounts swapped may not be larger than this percentage of total balance.
-
-export const _MAX_IN_RATIO: BigNumber = parseFixed('0.3', 18);
-export const _MAX_OUT_RATIO: BigNumber = parseFixed('0.3', 18);
+import { BigNumber } from '@ethersproject/bignumber';
 
 // SQRT constants
 
@@ -29,3 +24,6 @@ export const MIDDECIMAL = BigNumber.from(10).pow(9); // splits the fixed point d
 // less-than-ideal starting point, which is important when alpha is small.
 export const _INVARIANT_SHRINKING_FACTOR_PER_STEP = 8;
 export const _INVARIANT_MIN_ITERATIONS = 5;
+
+// Swap Limit factor
+export const SWAP_LIMIT_FACTOR = BigNumber.from('999999000000000000');

--- a/src/pools/gyro3Pool/helpers.ts
+++ b/src/pools/gyro3Pool/helpers.ts
@@ -2,8 +2,6 @@ import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import bn from 'bignumber.js';
 import { WeiPerEther as ONE } from '@ethersproject/constants';
 import {
-    _MAX_IN_RATIO,
-    _MAX_OUT_RATIO,
     SQRT_1E_NEG_1,
     SQRT_1E_NEG_3,
     SQRT_1E_NEG_5,

--- a/test/gyro2Pool.spec.ts
+++ b/test/gyro2Pool.spec.ts
@@ -59,7 +59,7 @@ describe('Gyro2Pool tests USDC > DAI', () => {
                 SwapTypes.SwapExactIn
             );
 
-            expect(amount.toString()).to.eq('1243.745084463437699999');
+            expect(amount.toString()).to.eq('1243.74395782517101711');
 
             amount = pool.getLimitAmountSwap(
                 poolPairData,

--- a/test/gyro2Pool.spec.ts
+++ b/test/gyro2Pool.spec.ts
@@ -59,14 +59,14 @@ describe('Gyro2Pool tests USDC > DAI', () => {
                 SwapTypes.SwapExactIn
             );
 
-            expect(amount.toString()).to.eq('300');
+            expect(amount.toString()).to.eq('1243.745084463437699999');
 
             amount = pool.getLimitAmountSwap(
                 poolPairData,
                 SwapTypes.SwapExactOut
             );
 
-            expect(amount.toString()).to.eq('369.6');
+            expect(amount.toString()).to.eq('1231.998768');
         });
     });
 

--- a/test/gyro3Pool.spec.ts
+++ b/test/gyro3Pool.spec.ts
@@ -1,6 +1,7 @@
+// TS_NODE_PROJECT='tsconfig.testing.json' npx mocha -r ts-node/register test/gyro3Pool.spec.ts
 import { expect } from 'chai';
 import cloneDeep from 'lodash.clonedeep';
-import { formatFixed, parseFixed, BigNumber } from '@ethersproject/bignumber';
+import { formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { bnum } from '../src/utils/bignumber';
 import { USDC, USDT } from './lib/constants';
 import { SwapTypes } from '../src';
@@ -38,14 +39,14 @@ describe('Gyro3Pool tests USDC > DAI', () => {
                 SwapTypes.SwapExactIn
             );
 
-            expect(amount.toString()).to.eq('24935.7');
+            expect(amount.toString()).to.eq('82089.998821185751004412');
 
             amount = pool.getLimitAmountSwap(
                 poolPairData,
                 SwapTypes.SwapExactOut
             );
 
-            expect(amount.toString()).to.eq('24445.5');
+            expect(amount.toString()).to.eq('81484.918515');
         });
     });
 


### PR DESCRIPTION
Previously a hard-cap of 30% of the asset quantity was hard-coded to be the limit. Now the limit has been removed and swap fees have been taken into consideration.