### PR TITLE
Refresh cache if useBpts changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@balancer-labs/sor",
-    "version": "4.0.1-beta.8",
+    "version": "4.0.1-beta.9",
     "license": "GPL-3.0-only",
     "main": "dist/index.js",
     "module": "dist/index.esm.js",

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -30,6 +30,7 @@ export class SOR {
     private readonly poolCacher: PoolCacher;
     public readonly routeProposer: RouteProposer;
     readonly swapCostCalculator: SwapCostCalculator;
+    private useBpt: boolean;
 
     private readonly defaultSwapOptions: SwapOptions = {
         gasPrice: parseFixed('50', 9),
@@ -89,7 +90,7 @@ export class SOR {
         swapType: SwapTypes,
         swapAmount: BigNumberish,
         swapOptions?: Partial<SwapOptions>,
-        useBpts?: boolean
+        useBpts = false
     ): Promise<SwapInfo> {
         if (!this.poolCacher.finishedFetching) return cloneDeep(EMPTY_SWAPINFO);
 
@@ -98,7 +99,10 @@ export class SOR {
             ...this.defaultSwapOptions,
             ...swapOptions,
         };
-
+        if (this.useBpt !== useBpts) {
+            options.forceRefresh = true;
+            this.useBpt = useBpts;
+        }
         const pools: SubgraphPoolBase[] = this.poolCacher.getPools(useBpts);
         const filteredPools = filterPoolsByType(pools, options.poolTypeFilter);
 

--- a/test/testScripts/constants.ts
+++ b/test/testScripts/constants.ts
@@ -169,6 +169,11 @@ export const ADDRESSES = {
             decimals: 18,
             symbol: 'rETH',
         },
+        auraBal: {
+            address: '0x616e8bfa43f920657b3497dbf40d6b1a02d4608d',
+            decimals: 18,
+            symbol: 'auraBal',
+        },
     },
     [Network.KOVAN]: {
         // Visit https://balancer-faucet.on.fleek.co/#/faucet for test tokens

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -65,10 +65,10 @@ export async function swap(): Promise<void> {
     const gasPrice = BigNumber.from('40000000000');
     // This determines the max no of pools the SOR will use to swap.
     const maxPools = 4;
-    const tokenIn = ADDRESSES[networkId].USDC;
-    const tokenOut = ADDRESSES[networkId].WETH;
-    const swapType: SwapTypes = SwapTypes.SwapExactOut;
-    const swapAmount = parseFixed('1.7', 18);
+    const tokenIn = ADDRESSES[networkId].WETH;
+    const tokenOut = ADDRESSES[networkId].DAI;
+    const swapType: SwapTypes = SwapTypes.SwapExactIn;
+    const swapAmount = parseFixed('1', 18);
 
     const sor = setUp(networkId, provider);
 
@@ -82,7 +82,7 @@ export async function swap(): Promise<void> {
         swapType,
         swapAmount,
         { gasPrice, maxPools },
-        true
+        false
     );
 
     // Simulate the swap transaction


### PR DESCRIPTION
Changing useBpts for different `getSwaps` calls wouldn't have any effect as the paths cache was being used. This forces a refresh of the cache if the useBpts value has changed.