### PR TITLE
Fix no path bug.

### DIFF
--- a/src/router/sorClass.ts
+++ b/src/router/sorClass.ts
@@ -388,18 +388,29 @@ function getBestPathIds(
         });
 
         if (bestPathIndex === -1) {
-            return [[], []];
-        }
-
-        selectedPaths.push(paths[bestPathIndex]);
-        selectedPathExceedingAmounts.push(
-            swapAmount.minus(
-                bnum(
-                    formatFixed(paths[bestPathIndex].limitAmount, inputDecimals)
+            selectedPaths.push({
+                id: '',
+                swaps: [],
+                poolPairData: [],
+                limitAmount: BigNumber.from('0'),
+                pools: [],
+            });
+            selectedPathExceedingAmounts.push(ZERO);
+            return;
+        } else {
+            selectedPaths.push(paths[bestPathIndex]);
+            selectedPathExceedingAmounts.push(
+                swapAmount.minus(
+                    bnum(
+                        formatFixed(
+                            paths[bestPathIndex].limitAmount,
+                            inputDecimals
+                        )
+                    )
                 )
-            )
-        );
-        paths.splice(bestPathIndex, 1); // Remove path from list
+            );
+            paths.splice(bestPathIndex, 1); // Remove path from list
+        }
     });
 
     return [selectedPaths, selectedPathExceedingAmounts];

--- a/test/testScripts/constants.ts
+++ b/test/testScripts/constants.ts
@@ -332,6 +332,21 @@ export const ADDRESSES = {
             decimals: 18,
             symbol: 'dUSD',
         },
+        TUSD: {
+            address: '0x2e1ad108ff1d8c782fcbbb89aad783ac49586756',
+            decimals: 18,
+            symbol: 'TUSD',
+        },
+        TETUBAL: {
+            address: '0x7fC9E0Aa043787BFad28e29632AdA302C790Ce33',
+            decimals: 18,
+            symbol: 'TETUBAL',
+        },
+        WETHBAL: {
+            address: '0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f',
+            decimals: 18,
+            symbol: 'WETHBAL',
+        },
     },
     [Network.ARBITRUM]: {
         WETH: {

--- a/test/testScripts/swapExample.ts
+++ b/test/testScripts/swapExample.ts
@@ -65,10 +65,10 @@ export async function swap(): Promise<void> {
     const gasPrice = BigNumber.from('40000000000');
     // This determines the max no of pools the SOR will use to swap.
     const maxPools = 4;
-    const tokenIn = ADDRESSES[networkId].USDT;
-    const tokenOut = ADDRESSES[networkId].USDC;
+    const tokenIn = ADDRESSES[networkId].WETHBAL;
+    const tokenOut = ADDRESSES[networkId].TETUBAL;
     const swapType: SwapTypes = SwapTypes.SwapExactIn;
-    const swapAmount = parseFixed('1000', 6);
+    const swapAmount = parseFixed('7', 18);
 
     const sor = setUp(networkId, provider);
 


### PR DESCRIPTION
Issue with Polygon for this swap pair: https://app.balancer.fi/#/polygon/trade/0x3d468AB2329F296e1b9d8476Bb54Dd77D8c2320f/0x7fc9e0aa043787bfad28e29632ada302c790ce33
- Was failing to find bestPathIndex which led to exceedingAmounts and swapAmounts having different lengths. 
- Pushed empty values to maintain length.