### PR TITLE
Fix join and exit MetaStable pool maths

### DIFF
--- a/src/pools/composableStable/composableStablePool.ts
+++ b/src/pools/composableStable/composableStablePool.ts
@@ -186,7 +186,8 @@ export class ComposableStablePool extends PhantomStablePool {
      * @returns EVM scale.
      */
     _calcTokensOutGivenExactBptIn(bptAmountIn: BigNumber): BigNumber[] {
-        // token balances are stored in human scale in SG and must be normalized as if it had 18 decimals for maths.
+        // balances and amounts must be normalized as if it had 18 decimals for maths
+        // takes price rate into account
         const balancesNormalised = this.tokens
             .filter((t) => !isSameAddress(t.address, this.address))
             .map((t) => normaliseBalance(t));
@@ -213,14 +214,14 @@ export class ComposableStablePool extends PhantomStablePool {
      */
     _calcBptOutGivenExactTokensIn(amountsIn: BigNumber[]): BigNumber {
         try {
+            // balances and amounts must be normalized as if it had 18 decimals for maths
+            // takes price rate into account
             const amountsInNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
             const balancesNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
-            // token balances are stored in human scale and must be EVM for maths
-            // Must take priceRate into consideration
             this.tokens
                 .filter((t) => !isSameAddress(t.address, this.address))
                 .forEach((token, i) => {

--- a/src/pools/composableStable/composableStablePool.ts
+++ b/src/pools/composableStable/composableStablePool.ts
@@ -1,13 +1,13 @@
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
 import {
-    _computeScalingFactor,
-    _downscaleDown,
-    ONE as ONE_BigInt,
-} from '../../utils/basicOperations';
-import { isSameAddress } from '../../utils';
+    isSameAddress,
+    normaliseBalance,
+    normaliseAmount,
+    denormaliseAmount,
+} from '../../utils';
 import { BigNumber as OldBigNumber, bnum, ZERO } from '../../utils/bignumber';
-import { SubgraphPoolBase, SubgraphToken } from '../../types';
+import { SubgraphPoolBase } from '../../types';
 import {
     _calcBptOutGivenExactTokensIn,
     _calcTokenOutGivenExactBptIn,
@@ -180,26 +180,6 @@ export class ComposableStablePool extends PhantomStablePool {
         }
     }
 
-    // normalizes its balance as if it had 18 decimals taking price rate into consideration.
-    normalisedBalance(
-        token: Pick<SubgraphToken, 'balance' | 'priceRate'>
-    ): bigint {
-        return parseFixed(token.balance, 18)
-            .mul(parseFixed(token.priceRate, 18))
-            .div(ONE)
-            .toBigInt();
-    }
-
-    // denormalises amount from 18 decimals to token decimals taking price rate into consideration.
-    denormaliseAmount(
-        amount: bigint,
-        token: Pick<SubgraphToken, 'priceRate' | 'decimals'>
-    ): bigint {
-        const amountAfterRate = (amount * ONE_BigInt) / BigInt(token.priceRate);
-        const scalingFactor = _computeScalingFactor(BigInt(token.decimals));
-        return _downscaleDown(amountAfterRate, scalingFactor);
-    }
-
     /**
      * _calcTokensOutGivenExactBptIn
      * @param bptAmountIn EVM scale.
@@ -207,22 +187,22 @@ export class ComposableStablePool extends PhantomStablePool {
      */
     _calcTokensOutGivenExactBptIn(bptAmountIn: BigNumber): BigNumber[] {
         // token balances are stored in human scale in SG and must be normalized as if it had 18 decimals for maths.
-        const normalisedBalances = this.tokens
+        const balancesNormalised = this.tokens
             .filter((t) => !isSameAddress(t.address, this.address))
-            .map((t) => this.normalisedBalance(t));
+            .map((t) => normaliseBalance(t));
         try {
             const amountsOutNormalised = _calcTokensOutGivenExactBptIn(
-                normalisedBalances,
+                balancesNormalised,
                 bptAmountIn.toBigInt(),
                 this.totalShares.toBigInt()
             );
             // We want to return denormalised amounts. e.g. 1USDC should be 1e6 not 1e18
-            const amountsDenormalised = amountsOutNormalised.map((a, i) =>
-                this.denormaliseAmount(a, this.tokens[i])
+            const amountsOut = amountsOutNormalised.map((a, i) =>
+                denormaliseAmount(a, this.tokens[i])
             );
-            return amountsDenormalised.map((a) => BigNumber.from(a));
+            return amountsOut.map((a) => BigNumber.from(a));
         } catch (err) {
-            return new Array(normalisedBalances.length).fill(ZERO);
+            return new Array(balancesNormalised.length).fill(ZERO);
         }
     }
 
@@ -233,31 +213,27 @@ export class ComposableStablePool extends PhantomStablePool {
      */
     _calcBptOutGivenExactTokensIn(amountsIn: BigNumber[]): BigNumber {
         try {
-            const amountsInHuman = amountsIn.map((amount, i) =>
-                formatFixed(amount, this.tokens[i].decimals)
-            );
-            const amountsInWithRate = new Array(amountsIn.length).fill(
+            const amountsInNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
-            const balancesEvm = new Array(amountsIn.length).fill(BigInt(0));
+            const balancesNormalised = new Array(amountsIn.length).fill(
+                BigInt(0)
+            );
             // token balances are stored in human scale and must be EVM for maths
             // Must take priceRate into consideration
             this.tokens
                 .filter((t) => !isSameAddress(t.address, this.address))
-                .forEach(({ balance, priceRate }, i) => {
-                    amountsInWithRate[i] = parseFixed(amountsInHuman[i], 18) // 18 decimals required for maths
-                        .mul(parseFixed(priceRate, 18))
-                        .div(ONE)
-                        .toBigInt();
-                    balancesEvm[i] = parseFixed(balance, 18)
-                        .mul(parseFixed(priceRate, 18))
-                        .div(ONE)
-                        .toBigInt();
+                .forEach((token, i) => {
+                    amountsInNormalised[i] = normaliseAmount(
+                        BigInt(amountsIn[i].toString()),
+                        token
+                    );
+                    balancesNormalised[i] = normaliseBalance(token);
                 });
             const bptAmountOut = _calcBptOutGivenExactTokensIn(
                 this.amp.toBigInt(),
-                balancesEvm,
-                amountsInWithRate,
+                balancesNormalised,
+                amountsInNormalised,
                 this.totalShares.toBigInt(),
                 this.swapFee.toBigInt()
             );

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -1,6 +1,11 @@
 import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
 import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
-import { isSameAddress } from '../../utils';
+import {
+    isSameAddress,
+    normaliseBalance,
+    normaliseAmount,
+    denormaliseAmount,
+} from '../../utils';
 import { BigNumber as OldBigNumber, bnum, ZERO } from '../../utils/bignumber';
 import {
     PoolBase,
@@ -301,30 +306,22 @@ export class MetaStablePool implements PoolBase<MetaStablePoolPairData> {
      * @returns EVM scale.
      */
     _calcTokensOutGivenExactBptIn(bptAmountIn: BigNumber): BigNumber[] {
-        // token balances are stored in human scale and must be EVM for maths
-        // Must take priceRate into consideration
-        const balancesEvm = this.tokens
+        // token balances are stored in human scale in SG and must be normalized as if it had 18 decimals for maths.
+        const balancesNormalised = this.tokens
             .filter((t) => !isSameAddress(t.address, this.address))
-            .map(({ balance, priceRate, decimals }) =>
-                parseFixed(balance, decimals)
-                    .mul(parseFixed(priceRate, 18))
-                    .div(ONE)
-                    .toBigInt()
-            );
+            .map((t) => normaliseBalance(t));
         try {
-            const amountsOutWithRate = _calcTokensOutGivenExactBptIn(
-                balancesEvm,
+            const amountsOutNormalised = _calcTokensOutGivenExactBptIn(
+                balancesNormalised,
                 bptAmountIn.toBigInt(),
                 this.totalShares.toBigInt()
             );
-            const amountsOut = amountsOutWithRate.map((amount, i) =>
-                BigNumber.from(amount.toString())
-                    .mul(ONE)
-                    .div(this.tokens[i].priceRate)
+            const amountsOut = amountsOutNormalised.map((a, i) =>
+                BigNumber.from(denormaliseAmount(a, this.tokens[i]).toString())
             );
             return amountsOut;
         } catch (err) {
-            return new Array(balancesEvm.length).fill(ZERO);
+            return new Array(balancesNormalised.length).fill(ZERO);
         }
     }
 
@@ -335,28 +332,27 @@ export class MetaStablePool implements PoolBase<MetaStablePoolPairData> {
      */
     _calcBptOutGivenExactTokensIn(amountsIn: BigNumber[]): BigNumber {
         try {
-            const amountsInWithRate = new Array(amountsIn.length).fill(
+            const amountsInNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
-            const balancesEvm = new Array(amountsIn.length).fill(BigInt(0));
+            const balancesNormalised = new Array(amountsIn.length).fill(
+                BigInt(0)
+            );
             // token balances are stored in human scale and must be EVM for maths
             // Must take priceRate into consideration
             this.tokens
                 .filter((t) => !isSameAddress(t.address, this.address))
-                .forEach(({ balance, priceRate, decimals }, i) => {
-                    amountsInWithRate[i] = amountsIn[i]
-                        .mul(parseFixed(priceRate, 18))
-                        .div(ONE)
-                        .toBigInt();
-                    balancesEvm[i] = parseFixed(balance, decimals)
-                        .mul(parseFixed(priceRate, 18))
-                        .div(ONE)
-                        .toBigInt();
+                .forEach((token, i) => {
+                    amountsInNormalised[i] = normaliseAmount(
+                        BigInt(amountsIn[i].toString()),
+                        token
+                    );
+                    balancesNormalised[i] = normaliseBalance(token);
                 });
             const bptAmountOut = _calcBptOutGivenExactTokensIn(
                 this.amp.toBigInt(),
-                balancesEvm,
-                amountsInWithRate,
+                balancesNormalised,
+                amountsInNormalised,
                 this.totalShares.toBigInt(),
                 this.swapFee.toBigInt()
             );

--- a/src/pools/metaStablePool/metaStablePool.ts
+++ b/src/pools/metaStablePool/metaStablePool.ts
@@ -306,7 +306,8 @@ export class MetaStablePool implements PoolBase<MetaStablePoolPairData> {
      * @returns EVM scale.
      */
     _calcTokensOutGivenExactBptIn(bptAmountIn: BigNumber): BigNumber[] {
-        // token balances are stored in human scale in SG and must be normalized as if it had 18 decimals for maths.
+        // balances and amounts must be normalized as if it had 18 decimals for maths
+        // takes price rate into account
         const balancesNormalised = this.tokens
             .filter((t) => !isSameAddress(t.address, this.address))
             .map((t) => normaliseBalance(t));
@@ -332,14 +333,14 @@ export class MetaStablePool implements PoolBase<MetaStablePoolPairData> {
      */
     _calcBptOutGivenExactTokensIn(amountsIn: BigNumber[]): BigNumber {
         try {
+            // balances and amounts must be normalized as if it had 18 decimals for maths
+            // takes price rate into account
             const amountsInNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
             const balancesNormalised = new Array(amountsIn.length).fill(
                 BigInt(0)
             );
-            // token balances are stored in human scale and must be EVM for maths
-            // Must take priceRate into consideration
             this.tokens
                 .filter((t) => !isSameAddress(t.address, this.address))
                 .forEach((token, i) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,13 @@
 import { getAddress } from '@ethersproject/address';
 import { parseFixed, BigNumber } from '@ethersproject/bignumber';
+import { WeiPerEther as ONE } from '@ethersproject/constants';
+import {
+    _computeScalingFactor,
+    _downscaleDown,
+    ONE as ONE_BigInt,
+    _upscale,
+} from './basicOperations';
+import { SubgraphToken } from '../types';
 
 export const isSameAddress = (address1: string, address2: string): boolean =>
     getAddress(address1) === getAddress(address2);
@@ -14,3 +22,37 @@ export function safeParseFixed(value: string, decimals = 0): BigNumber {
     const safeValue = integer + '.' + fraction.slice(0, decimals);
     return parseFixed(safeValue, decimals);
 }
+
+// normalizes its balance as if it had 18 decimals taking price rate into consideration.
+export const normaliseBalance = (
+    token: Pick<SubgraphToken, 'balance' | 'priceRate'>
+): bigint => {
+    return parseFixed(token.balance, 18)
+        .mul(parseFixed(token.priceRate, 18))
+        .div(ONE)
+        .toBigInt();
+};
+
+// normalizes amount as if it had 18 decimals taking price rate into consideration.
+export const normaliseAmount = (
+    amount: bigint,
+    token: Pick<SubgraphToken, 'priceRate' | 'decimals'>
+): bigint => {
+    const scalingFactor = _computeScalingFactor(BigInt(token.decimals));
+    return BigNumber.from(_upscale(amount, scalingFactor).toString())
+        .mul(parseFixed(token.priceRate, 18))
+        .div(ONE)
+        .toBigInt();
+};
+
+// denormalises amount from 18 decimals to token decimals taking price rate into consideration.
+export const denormaliseAmount = (
+    amount: bigint,
+    token: Pick<SubgraphToken, 'priceRate' | 'decimals'>
+): bigint => {
+    const amountAfterRate =
+        (amount * ONE_BigInt) /
+        BigInt(parseFixed(token.priceRate, 18).toString());
+    const scalingFactor = _computeScalingFactor(BigInt(token.decimals));
+    return _downscaleDown(amountAfterRate, scalingFactor);
+};

--- a/test/ComposableStable.integration.spec.ts
+++ b/test/ComposableStable.integration.spec.ts
@@ -8,19 +8,13 @@ import {
 } from '@balancer-labs/typechain';
 import { vaultAddr } from './testScripts/constants';
 import { SubgraphPoolBase, SwapTypes, SOR, bnum } from '../src';
-import {
-    Network,
-    MULTIADDR,
-    SOR_CONFIG,
-    ADDRESSES,
-} from './testScripts/constants';
-import { OnChainPoolDataService } from './lib/onchainData';
-import { TokenPriceService } from '../src';
+import { Network, ADDRESSES } from './testScripts/constants';
 import { AddressZero } from '@ethersproject/constants';
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { expect } from 'chai';
 import { closeTo } from './lib/testHelpers';
 import { ComposableStablePool } from '../src/pools/composableStable/composableStablePool';
+import { setUp } from './testScripts/utils';
 
 dotenv.config();
 
@@ -28,6 +22,7 @@ let sor: SOR;
 const networkId = Network.MAINNET;
 const { ALCHEMY_URL: jsonRpcUrl } = process.env;
 const rpcUrl = 'http://127.0.0.1:8545';
+const blockNumber = 16447247;
 const provider = new JsonRpcProvider(rpcUrl, networkId);
 const vault = Vault__factory.connect(vaultAddr, provider);
 const bbausdt = ADDRESSES[networkId].bbausdt2.address;
@@ -39,7 +34,6 @@ const funds = {
     fromInternalBalance: false,
     toInternalBalance: false,
 };
-let subgraphPoolDataService: OnChainPoolDataService;
 
 // bbausd
 const testPool: SubgraphPoolBase = {
@@ -144,39 +138,6 @@ const testPool1: SubgraphPoolBase = {
     totalWeight: '0',
 };
 
-// Setup SOR with data services
-function setUp(networkId: Network, provider: JsonRpcProvider): SOR {
-    // The SOR needs to fetch pool data from an external source. This provider fetches from Subgraph and onchain calls.
-    subgraphPoolDataService = new OnChainPoolDataService({
-        vaultAddress: vaultAddr,
-        multiAddress: MULTIADDR[networkId],
-        provider,
-        pools: [testPool, testPool1],
-    });
-
-    class CoingeckoTokenPriceService implements TokenPriceService {
-        constructor(private readonly chainId: number) {}
-        async getNativeAssetPriceInToken(
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            tokenAddress: string
-        ): Promise<string> {
-            return '0';
-        }
-    }
-
-    // Use coingecko to fetch token price information. Used to calculate cost of additonal swaps/hops.
-    const coingeckoTokenPriceService = new CoingeckoTokenPriceService(
-        networkId
-    );
-
-    return new SOR(
-        provider,
-        SOR_CONFIG[networkId],
-        subgraphPoolDataService,
-        coingeckoTokenPriceService
-    );
-}
-
 export async function queryJoin(
     network: number,
     poolId: string,
@@ -248,24 +209,20 @@ export async function querySingleTokenExit(
 }
 
 describe('ComposableStable', () => {
+    // Setup chain
+    before(async function () {
+        this.timeout(20000);
+
+        sor = await setUp(
+            networkId,
+            provider,
+            [testPool, testPool1],
+            jsonRpcUrl as string,
+            blockNumber
+        );
+        await sor.fetchPools();
+    });
     context('test swaps vs queryBatchSwap', () => {
-        // Setup chain
-        before(async function () {
-            this.timeout(20000);
-
-            await provider.send('hardhat_reset', [
-                {
-                    forking: {
-                        jsonRpcUrl,
-                        blockNumber: 16447247,
-                    },
-                },
-            ]);
-
-            sor = setUp(networkId, provider);
-            await sor.fetchPools();
-        });
-
         context('ExactIn', () => {
             it('token>token', async () => {
                 const swapType = SwapTypes.SwapExactIn;
@@ -404,22 +361,6 @@ describe('ComposableStable', () => {
         });
     });
     context('test joins vs queryJoin', () => {
-        // Setup chain
-        before(async function () {
-            this.timeout(20000);
-
-            await provider.send('hardhat_reset', [
-                {
-                    forking: {
-                        jsonRpcUrl,
-                        blockNumber: 16447247,
-                    },
-                },
-            ]);
-
-            sor = setUp(networkId, provider);
-            await sor.fetchPools();
-        });
         context('Joins', () => {
             it('Join with many tokens', async () => {
                 const bptIndex = 2;
@@ -432,7 +373,7 @@ describe('ComposableStable', () => {
                 const amountsWithOutBpt = [...amountsInWithBpt];
                 amountsWithOutBpt.splice(bptIndex, 1);
 
-                const pools = await subgraphPoolDataService.getPools();
+                const pools = sor.getPools();
                 const pool = ComposableStablePool.fromPool(pools[0]);
                 const bptCalculated =
                     pool._calcBptOutGivenExactTokensIn(amountsWithOutBpt);
@@ -462,7 +403,7 @@ describe('ComposableStable', () => {
                 const amountsWithOutBpt = [...amountsInWithBpt];
                 amountsWithOutBpt.splice(bptIndex, 1);
 
-                const pools = await subgraphPoolDataService.getPools();
+                const pools = sor.getPools();
                 const pool = ComposableStablePool.fromPool(pools[0]);
                 const bptCalculated =
                     pool._calcBptOutGivenExactTokensIn(amountsWithOutBpt);
@@ -484,28 +425,12 @@ describe('ComposableStable', () => {
         });
     });
     context('test exits vs queryExit', () => {
-        // Setup chain
-        before(async function () {
-            this.timeout(20000);
-
-            await provider.send('hardhat_reset', [
-                {
-                    forking: {
-                        jsonRpcUrl,
-                        blockNumber: 16447247,
-                    },
-                },
-            ]);
-
-            sor = setUp(networkId, provider);
-            await sor.fetchPools();
-        });
         context('Exits', () => {
             it('BPT>token', async () => {
                 const tokenIndex = 0;
                 const bptInHuman = '977.234';
                 const bptInEvm = parseFixed(bptInHuman, 18);
-                const pools = await subgraphPoolDataService.getPools();
+                const pools = sor.getPools();
                 const pool = ComposableStablePool.fromPool(pools[0]);
                 const pairData = pool.parsePoolPairData(
                     testPool.address,
@@ -539,7 +464,7 @@ describe('ComposableStable', () => {
             //     const tokenIndex = 2; // usdc
             //     const bptInHuman = '10.10';
             //     const bptInEvm = parseFixed(bptInHuman, 18);
-            //     const pools = await subgraphPoolDataService.getPools();
+            //     const pools = sor.getPools();
             //     const pool = ComposableStablePool.fromPool(pools[1]);
             //     const pairData = pool.parsePoolPairData(
             //         pool.address,
@@ -572,7 +497,7 @@ describe('ComposableStable', () => {
             // ComposableStable V1 does not have this functionality but V2 does
             // it('BPT>tokens', async () => {
             //     const bptIn = parseFixed('77', 18);
-            //     const pools = await subgraphPoolDataService.getPools();
+            //     const pools = sor.getPools();
             //     const pool = ComposableStablePool.fromPool(pools[0]);
             //     const amountOut = pool._calcTokensOutGivenExactBptIn(bptIn);
             //     console.log(amountOut.toString());

--- a/test/ComposableStable.integration.spec.ts
+++ b/test/ComposableStable.integration.spec.ts
@@ -534,39 +534,41 @@ describe('ComposableStable', () => {
                     else expect(a.toString()).to.eq('0');
                 });
             }).timeout(10000);
-            it('BPT>token with less than 18 decimals', async () => {
-                const tokenIndex = 2; // usdc
-                const bptInHuman = '10.10';
-                const bptInEvm = parseFixed(bptInHuman, 18);
-                const pools = await subgraphPoolDataService.getPools();
-                const pool = ComposableStablePool.fromPool(pools[1]);
-                const pairData = pool.parsePoolPairData(
-                    pool.address,
-                    pool.tokensList[tokenIndex]
-                );
-                const amountOutHuman = pool._exactTokenInForTokenOut(
-                    pairData,
-                    bnum(bptInHuman)
-                );
-                const amountOutEvm = parseFixed(
-                    amountOutHuman.toString(),
-                    pairData.decimalsOut
-                );
+            // At the moment there is no ComposableStable pool containing a token with less than 18 decimals to test against
+            // it('BPT>token with less than 18 decimals', async () => {
+            //     const tokenIndex = 2; // usdc
+            //     const bptInHuman = '10.10';
+            //     const bptInEvm = parseFixed(bptInHuman, 18);
+            //     const pools = await subgraphPoolDataService.getPools();
+            //     const pool = ComposableStablePool.fromPool(pools[1]);
+            //     const pairData = pool.parsePoolPairData(
+            //         pool.address,
+            //         pool.tokensList[tokenIndex]
+            //     );
+            //     const amountOutHuman = pool._exactTokenInForTokenOut(
+            //         pairData,
+            //         bnum(bptInHuman)
+            //     );
+            //     const amountOutEvm = parseFixed(
+            //         amountOutHuman.toString(),
+            //         pairData.decimalsOut
+            //     );
 
-                const deltas = await querySingleTokenExit(
-                    networkId,
-                    pool.id,
-                    pool.tokensList,
-                    bptInEvm.toString(),
-                    tokenIndex
-                );
-                expect(deltas.bptIn.toString()).to.eq(bptInEvm.toString());
-                deltas.amountsOut.forEach((a, i) => {
-                    if (i === tokenIndex)
-                        expect(a.toString()).to.eq(amountOutEvm.toString());
-                    else expect(a.toString()).to.eq('0');
-                });
-            }).timeout(20000);
+            //     const deltas = await querySingleTokenExit(
+            //         networkId,
+            //         pool.id,
+            //         pool.tokensList,
+            //         bptInEvm.toString(),
+            //         tokenIndex
+            //     );
+            //     expect(deltas.bptIn.toString()).to.eq(bptInEvm.toString());
+            //     deltas.amountsOut.forEach((a, i) => {
+            //         if (i === tokenIndex)
+            //             expect(a.toString()).to.eq(amountOutEvm.toString());
+            //         else expect(a.toString()).to.eq('0');
+            //     });
+            // }).timeout(20000);
+
             // ComposableStable V1 does not have this functionality but V2 does
             // it('BPT>tokens', async () => {
             //     const bptIn = parseFixed('77', 18);

--- a/test/MetaStable.integration.spec.ts
+++ b/test/MetaStable.integration.spec.ts
@@ -1,0 +1,339 @@
+// yarn test:only test/MetaStable.integration.spec.ts
+import dotenv from 'dotenv';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { defaultAbiCoder } from '@ethersproject/abi';
+import { BalancerHelpers__factory } from '@balancer-labs/typechain';
+import { vaultAddr } from './testScripts/constants';
+import { SubgraphPoolBase, SOR } from '../src';
+import {
+    Network,
+    MULTIADDR,
+    SOR_CONFIG,
+    ADDRESSES,
+} from './testScripts/constants';
+import { OnChainPoolDataService } from './lib/onchainData';
+import { TokenPriceService } from '../src';
+import { AddressZero } from '@ethersproject/constants';
+import { BigNumber, formatFixed, parseFixed } from '@ethersproject/bignumber';
+import { expect } from 'chai';
+import { MetaStablePool } from '../src/pools/metaStablePool/metaStablePool';
+
+dotenv.config();
+
+// Balancer USDC-USDT Oracle Stable Pool
+const testPool: SubgraphPoolBase = {
+    id: '0x9f383f91c89cbd649c700c2bf69c2a828af299aa0002000000000000000003a6',
+    address: '0x9f383f91c89cbd649c700c2bf69c2a828af299aa',
+    swapEnabled: true,
+    poolType: 'MetaStable',
+    swapFee: '0.000001',
+    totalWeight: '0',
+    totalShares: '1.501763384758054657',
+    tokensList: [
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+        '0xdac17f958d2ee523a2206206994597c13d831ec7',
+    ],
+    tokens: [
+        {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            balance: '1.129827',
+            decimals: 6,
+            priceRate: '0.9992',
+            weight: null,
+        },
+        {
+            address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+            balance: '0.382611',
+            decimals: 6,
+            priceRate: '1',
+            weight: null,
+        },
+    ],
+};
+
+let sor: SOR;
+const networkId = Network.MAINNET;
+const { ALCHEMY_URL: jsonRpcUrl } = process.env;
+const rpcUrl = 'http://127.0.0.1:8545';
+const provider = new JsonRpcProvider(rpcUrl, networkId);
+let subgraphPoolDataService: OnChainPoolDataService;
+
+// Setup SOR with data services
+function setUp(networkId: Network, provider: JsonRpcProvider): SOR {
+    // The SOR needs to fetch pool data from an external source. This provider fetches from Subgraph and onchain calls.
+    subgraphPoolDataService = new OnChainPoolDataService({
+        vaultAddress: vaultAddr,
+        multiAddress: MULTIADDR[networkId],
+        provider,
+        pools: [testPool],
+    });
+
+    class CoingeckoTokenPriceService implements TokenPriceService {
+        constructor(private readonly chainId: number) {}
+        async getNativeAssetPriceInToken(
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            tokenAddress: string
+        ): Promise<string> {
+            return '0';
+        }
+    }
+
+    // Use coingecko to fetch token price information. Used to calculate cost of additonal swaps/hops.
+    const coingeckoTokenPriceService = new CoingeckoTokenPriceService(
+        networkId
+    );
+
+    return new SOR(
+        provider,
+        SOR_CONFIG[networkId],
+        subgraphPoolDataService,
+        coingeckoTokenPriceService
+    );
+}
+
+export async function queryJoin(
+    network: number,
+    poolId: string,
+    assets: string[],
+    amountsIn: string[]
+): Promise<
+    [BigNumber, BigNumber[]] & { bptOut: BigNumber; amountsIn: BigNumber[] }
+> {
+    const helpers = BalancerHelpers__factory.connect(
+        ADDRESSES[network].balancerHelpers,
+        provider
+    );
+    const EXACT_TOKENS_IN_FOR_BPT_OUT = 1; // Alternative is: TOKEN_IN_FOR_EXACT_BPT_OUT
+    const minimumBPT = '0';
+    const abi = ['uint256', 'uint256[]', 'uint256'];
+    const data = [EXACT_TOKENS_IN_FOR_BPT_OUT, amountsIn, minimumBPT];
+    const userDataEncoded = defaultAbiCoder.encode(abi, data);
+    const joinPoolRequest = {
+        assets,
+        maxAmountsIn: amountsIn,
+        userData: userDataEncoded,
+        fromInternalBalance: false,
+    };
+
+    /*
+    {
+      "assets": [
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "0xdac17f958d2ee523a2206206994597c13d831ec7"
+      ],
+      "maxAmountsIn": [ "12300", "45600" ],
+      "userData": "0x0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000300c000000000000000000000000000000000000000000000000000000000000b220",
+      "fromInternalBalance": false
+    }
+    */
+
+    const query = await helpers.queryJoin(
+        poolId,
+        AddressZero, // Not important for query
+        AddressZero,
+        joinPoolRequest
+    );
+    return query;
+}
+
+export async function queryExit(
+    network: number,
+    poolId: string,
+    assets: string[],
+    bptAmountIn: string
+): Promise<
+    [BigNumber, BigNumber[]] & { bptIn: BigNumber; amountsOut: BigNumber[] }
+> {
+    const helpers = BalancerHelpers__factory.connect(
+        ADDRESSES[network].balancerHelpers,
+        provider
+    );
+    const EXACT_BPT_IN_FOR_TOKENS_OUT = 1; // Alternative is: BPT_IN_FOR_EXACT_TOKENS_OUT (No proportional)
+    const abi = ['uint256', 'uint256'];
+
+    const data = [EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn];
+    const userDataEncoded = defaultAbiCoder.encode(abi, data);
+
+    const exitPoolRequest = {
+        assets,
+        minAmountsOut: assets.map(() => '0'),
+        userData: userDataEncoded,
+        toInternalBalance: false,
+    };
+    const query = await helpers.queryExit(
+        poolId,
+        AddressZero, // Not important for query
+        AddressZero,
+        exitPoolRequest
+    );
+    return query;
+}
+
+export async function querySingleTokenExit(
+    network: number,
+    poolId: string,
+    assets: string[],
+    bptAmountIn: string,
+    exitTokenIndex: number
+): Promise<
+    [BigNumber, BigNumber[]] & { bptIn: BigNumber; amountsOut: BigNumber[] }
+> {
+    const helpers = BalancerHelpers__factory.connect(
+        ADDRESSES[network].balancerHelpers,
+        provider
+    );
+    const EXACT_BPT_IN_FOR_ONE_TOKEN_OUT = 0; // Alternative is: BPT_IN_FOR_EXACT_TOKENS_OUT (No proportional)
+    const abi = ['uint256', 'uint256', 'uint256'];
+
+    const data = [EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, bptAmountIn, exitTokenIndex];
+    const userDataEncoded = defaultAbiCoder.encode(abi, data);
+
+    const exitPoolRequest = {
+        assets,
+        minAmountsOut: assets.map(() => '0'),
+        userData: userDataEncoded,
+        toInternalBalance: false,
+    };
+    const query = await helpers.queryExit(
+        poolId,
+        AddressZero, // Not important for query
+        AddressZero,
+        exitPoolRequest
+    );
+    return query;
+}
+
+describe('MetaStable', () => {
+    context('test joins vs queryJoin', () => {
+        // Setup chain
+        before(async function () {
+            this.timeout(20000);
+
+            await provider.send('hardhat_reset', [
+                {
+                    forking: {
+                        jsonRpcUrl,
+                        blockNumber: 16447247,
+                    },
+                },
+            ]);
+
+            sor = setUp(networkId, provider);
+            await sor.fetchPools();
+        });
+        context('Joins', () => {
+            it('Join with many tokens', async () => {
+                const amountsIn = [
+                    parseFixed('0.0123', 6),
+                    parseFixed('0.0456', 6),
+                ];
+
+                const pools = await subgraphPoolDataService.getPools();
+                const pool = MetaStablePool.fromPool(pools[0]);
+                const bptOut = pool._calcBptOutGivenExactTokensIn(amountsIn);
+
+                const deltas = await queryJoin(
+                    networkId,
+                    testPool.id,
+                    testPool.tokensList,
+                    amountsIn.map((a) => a.toString())
+                );
+                console.log('bptOut       ', formatFixed(bptOut, 18));
+                console.log('delta bptOut ', formatFixed(deltas.bptOut, 18));
+                // TODO: check if it's ok to have a small difference - diff comes from divDown not matching between TS and SC math
+                expect(bptOut.sub(deltas.bptOut).toNumber()).to.closeTo(0, 1);
+                expect(deltas.amountsIn.toString()).to.eq(amountsIn.toString());
+            });
+            it('Join with single token', async () => {
+                const amountsIn = [parseFixed('0', 6), parseFixed('0.0789', 6)];
+                const pools = await subgraphPoolDataService.getPools();
+                const pool = MetaStablePool.fromPool(pools[0]);
+                const bptOut = pool._calcBptOutGivenExactTokensIn(amountsIn);
+
+                const deltas = await queryJoin(
+                    networkId,
+                    testPool.id,
+                    testPool.tokensList,
+                    amountsIn.map((a) => a.toString())
+                );
+                console.log('bptOut       ', formatFixed(bptOut, 18));
+                console.log('delta bptOut ', formatFixed(deltas.bptOut, 18));
+                // TODO: check if it's ok to have a small difference - diff comes from divDown not matching between TS and SC math
+                expect(bptOut.sub(deltas.bptOut).toNumber()).to.closeTo(0, 1);
+                expect(deltas.amountsIn.toString()).to.eq(amountsIn.toString());
+            });
+        });
+    });
+    context('test exits vs queryExit', () => {
+        // Setup chain
+        before(async function () {
+            this.timeout(20000);
+
+            await provider.send('hardhat_reset', [
+                {
+                    forking: {
+                        jsonRpcUrl,
+                        blockNumber: 16447247,
+                    },
+                },
+            ]);
+
+            sor = setUp(networkId, provider);
+            await sor.fetchPools();
+        });
+        context('Exits', () => {
+            // TODO: pending single token out implementation on metaStable pool
+            // it('BPT>token', async () => {
+            //     const tokenIndex = 0; // usdc
+            //     const bptInHuman = '0.123';
+            //     const bptInEvm = parseFixed(bptInHuman, 18);
+            //     const pools = await subgraphPoolDataService.getPools();
+            //     const pool = MetaStablePool.fromPool(pools[0]);
+            //     const pairData = pool.parsePoolPairData(
+            //         testPool.address,
+            //         pool.tokensList[tokenIndex]
+            //     );
+            //     const amountOutHuman = pool._exactTokenInForTokenOut(
+            //         pairData,
+            //         bnum(bptInHuman)
+            //     );
+            //     const amountOutEvm = parseFixed(
+            //         amountOutHuman.toString(),
+            //         pairData.decimalsOut
+            //     );
+
+            //     const deltas = await querySingleTokenExit(
+            //         networkId,
+            //         testPool.id,
+            //         testPool.tokensList,
+            //         bptInEvm.toString(),
+            //         tokenIndex
+            //     );
+            //     expect(deltas.bptIn.toString()).to.eq(bptInEvm.toString());
+            //     deltas.amountsOut.forEach((a, i) => {
+            //         if (i === tokenIndex)
+            //             expect(a.toString()).to.eq(amountOutEvm.toString());
+            //         else expect(a.toString()).to.eq('0');
+            //     });
+            // });
+            it('BPT>tokens', async () => {
+                const bptIn = parseFixed('0.0123', 18);
+                const pools = await subgraphPoolDataService.getPools();
+                const pool = MetaStablePool.fromPool(pools[0]);
+                const amountOut = pool._calcTokensOutGivenExactBptIn(bptIn);
+                const deltas = await queryExit(
+                    networkId,
+                    testPool.id,
+                    testPool.tokensList,
+                    bptIn.toString()
+                );
+                console.log('amountOut       ', amountOut.toString());
+                console.log('delta amountOut ', deltas.amountsOut.toString());
+                expect(deltas.bptIn.toString()).to.eq(bptIn.toString());
+                deltas.amountsOut.forEach((a, i) => {
+                    expect(a.toString()).to.eq(amountOut[i].toString());
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Changes:
- Move normalise/denormalise helpers into helper file
- Fix join/exit math for MetaStable pools
- Add integration tests for join/exit MetaStable pools

Side notes:
- move `normalised` to the end of variable names, to keep a standard - e.g. `balancesNormalised` instead of `normalisedBalances`
- omit `denormalised` from variable names - e.g. `balances` instead of `balancesDenormalised`